### PR TITLE
Add sanitized Next.js public environment template

### DIFF
--- a/apps/web/.env.local.sample
+++ b/apps/web/.env.local.sample
@@ -1,0 +1,32 @@
+# Public Plane web application settings for local development
+# All values are safe defaults and can be overridden per environment.
+
+# Core API routing
+NEXT_PUBLIC_API_BASE_URL="http://localhost:8000"
+NEXT_PUBLIC_API_BASE_PATH=""
+
+# Primary web surface URLs
+NEXT_PUBLIC_WEB_BASE_URL="http://localhost:3000"
+NEXT_PUBLIC_WEB_BASE_PATH=""
+NEXT_PUBLIC_ADMIN_BASE_URL="http://localhost:3001"
+NEXT_PUBLIC_ADMIN_BASE_PATH="/god-mode"
+NEXT_PUBLIC_SPACE_BASE_URL="http://localhost:3002"
+NEXT_PUBLIC_SPACE_BASE_PATH="/spaces"
+NEXT_PUBLIC_LIVE_BASE_URL="http://localhost:3100"
+NEXT_PUBLIC_LIVE_BASE_PATH="/live"
+
+# Shared marketing and support metadata
+NEXT_PUBLIC_WEBSITE_URL="https://plane.so"
+NEXT_PUBLIC_SUPPORT_EMAIL="support@plane.so"
+
+# Analytics and telemetry (leave blank to disable)
+NEXT_PUBLIC_PLAUSIBLE_DOMAIN=""
+NEXT_PUBLIC_POSTHOG_KEY=""
+NEXT_PUBLIC_POSTHOG_HOST="https://app.posthog.com"
+NEXT_PUBLIC_POSTHOG_DEBUG="0"
+NEXT_PUBLIC_ENABLE_SESSION_RECORDER="0"
+NEXT_PUBLIC_SESSION_RECORDER_KEY=""
+NEXT_PUBLIC_CRISP_ID=""
+
+# Media configuration
+NEXT_PUBLIC_EXTRA_IMAGE_DOMAINS=""


### PR DESCRIPTION
## Summary
- add a committed .env.local sample with safe defaults for the Plane web app
- document the public Next.js environment variables required for local development

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d749a5f6cc8329a233effd9f8ee988