### PR TITLE
Add client monitoring provider

### DIFF
--- a/apps/web/app/provider.tsx
+++ b/apps/web/app/provider.tsx
@@ -18,6 +18,7 @@ import "@/lib/polyfills";
 import { StoreProvider } from "@/lib/store-context";
 // wrappers
 import { InstanceWrapper } from "@/lib/wrappers";
+import { MonitoringProvider } from "@/lib/monitoring";
 // dynamic imports
 const StoreWrapper = dynamic(() => import("@/lib/wrappers/store-wrapper"), { ssr: false });
 const PostHogProvider = dynamic(() => import("@/lib/posthog-provider"), { ssr: false });
@@ -46,7 +47,9 @@ export const AppProvider: FC<IAppProvider> = (props) => {
               <InstanceWrapper>
                 <IntercomProvider>
                   <PostHogProvider>
-                    <SWRConfig value={WEB_SWR_CONFIG}>{children}</SWRConfig>
+                    <MonitoringProvider>
+                      <SWRConfig value={WEB_SWR_CONFIG}>{children}</SWRConfig>
+                    </MonitoringProvider>
                   </PostHogProvider>
                 </IntercomProvider>
               </InstanceWrapper>

--- a/apps/web/core/lib/monitoring/app-monitor.ts
+++ b/apps/web/core/lib/monitoring/app-monitor.ts
@@ -1,0 +1,180 @@
+"use client";
+
+import { captureError } from "@/helpers/event-tracker.helper";
+
+type ErrorContext = Record<string, unknown>;
+
+type NormalizedError = {
+  name?: string;
+  message: string;
+  stack?: string;
+  cause?: unknown;
+};
+
+type EventSource = "error" | "unhandledrejection" | "manual";
+
+const DEDUPLICATION_WINDOW = 10_000; // 10 seconds
+
+const stringifyUnknown = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return value.message;
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    return String(value);
+  }
+};
+
+const normalizeError = (error: unknown): NormalizedError => {
+  if (error instanceof Error) {
+    const normalized: NormalizedError = {
+      name: error.name,
+      message: error.message,
+      stack: error.stack ?? undefined,
+    };
+    if ((error as { cause?: unknown }).cause) {
+      normalized.cause = stringifyUnknown((error as { cause?: unknown }).cause);
+    }
+    return normalized;
+  }
+
+  if (typeof error === "string") {
+    return { message: error };
+  }
+
+  if (typeof error === "object" && error !== null) {
+    const serialized = stringifyUnknown(error);
+    return { message: serialized };
+  }
+
+  return { message: String(error) };
+};
+
+const resolveKey = (error: NormalizedError): string => {
+  const stackFragment = error.stack ? error.stack.split("\n")[0] : "";
+  return [error.name ?? "Error", error.message, stackFragment].filter(Boolean).join(":");
+};
+
+const buildRuntimeContext = (): ErrorContext => {
+  if (typeof window === "undefined") return {};
+
+  const { location, navigator } = window;
+  return {
+    url: location?.href,
+    pathname: location?.pathname,
+    search: location?.search,
+    hash: location?.hash,
+    userAgent: navigator?.userAgent,
+    language: navigator?.language,
+    platform: navigator?.platform,
+    online: navigator?.onLine,
+  };
+};
+
+const reportThroughAnalytics = (
+  source: EventSource,
+  normalizedError: NormalizedError,
+  context?: ErrorContext
+) => {
+  captureError({
+    eventName: "app_monitor_error",
+    error: normalizedError,
+    payload: {
+      severity: "critical",
+      origin: source,
+    },
+    context: {
+      ...buildRuntimeContext(),
+      ...context,
+    },
+  });
+};
+
+export class AppMonitor {
+  private started = false;
+  private removeListeners: Array<() => void> = [];
+  private recentErrors = new Map<string, number>();
+
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleError = (event: ErrorEvent) => {
+      const normalized = normalizeError(event.error || event.message || "Unknown runtime error");
+      if (!this.shouldReport(normalized)) return;
+
+      reportThroughAnalytics("error", normalized, {
+        filename: event.filename,
+        lineno: event.lineno,
+        colno: event.colno,
+        type: event.type,
+        isTrusted: event.isTrusted,
+      });
+    };
+
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      const normalized = normalizeError(event.reason || "Unhandled rejection");
+      if (!this.shouldReport(normalized)) return;
+
+      reportThroughAnalytics("unhandledrejection", normalized, {
+        type: event.type,
+        isTrusted: event.isTrusted,
+      });
+    };
+
+    window.addEventListener("error", handleError);
+    this.removeListeners.push(() => window.removeEventListener("error", handleError));
+
+    window.addEventListener("unhandledrejection", handleUnhandledRejection);
+    this.removeListeners.push(() =>
+      window.removeEventListener("unhandledrejection", handleUnhandledRejection)
+    );
+  }
+
+  stop(): void {
+    if (!this.started) return;
+
+    while (this.removeListeners.length) {
+      const remove = this.removeListeners.pop();
+      try {
+        remove?.();
+      } catch (error) {
+        // Swallow removal errors silently
+      }
+    }
+
+    this.started = false;
+  }
+
+  captureException(error: unknown, context?: ErrorContext): void {
+    const normalized = normalizeError(error);
+    if (!this.shouldReport(normalized)) return;
+
+    reportThroughAnalytics("manual", normalized, context);
+  }
+
+  private shouldReport(error: NormalizedError): boolean {
+    const key = resolveKey(error);
+    const now = Date.now();
+    const lastTimestamp = this.recentErrors.get(key) ?? 0;
+
+    for (const [storedKey, timestamp] of this.recentErrors.entries()) {
+      if (now - timestamp > DEDUPLICATION_WINDOW) {
+        this.recentErrors.delete(storedKey);
+      }
+    }
+
+    if (now - lastTimestamp < DEDUPLICATION_WINDOW) {
+      return false;
+    }
+
+    this.recentErrors.set(key, now);
+    return true;
+  }
+}
+
+export const appMonitor = new AppMonitor();

--- a/apps/web/core/lib/monitoring/index.ts
+++ b/apps/web/core/lib/monitoring/index.ts
@@ -1,0 +1,2 @@
+export { MonitoringProvider } from "./monitoring-provider";
+export { appMonitor, AppMonitor } from "./app-monitor";

--- a/apps/web/core/lib/monitoring/monitoring-provider.tsx
+++ b/apps/web/core/lib/monitoring/monitoring-provider.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { FC, PropsWithChildren, useEffect } from "react";
+
+import { appMonitor } from "./app-monitor";
+
+type MonitoringProviderProps = PropsWithChildren<Record<string, never>>;
+
+export const MonitoringProvider: FC<MonitoringProviderProps> = ({ children }) => {
+  useEffect(() => {
+    appMonitor.start();
+    return () => {
+      appMonitor.stop();
+    };
+  }, []);
+
+  return <>{children}</>;
+};
+
+export default MonitoringProvider;


### PR DESCRIPTION
## Summary
- add an application monitor that normalizes runtime errors, deduplicates noisy reports, and enriches them with runtime context before forwarding to analytics
- provide a monitoring provider component that automatically starts/stops global listeners while keeping the rendered interface unchanged
- expose the monitor utilities through a central index so other modules can opt-in to manual reporting when needed

## Testing
- yarn --cwd apps/web check:types *(fails: repository already reports missing @plane/* workspace modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d749e476608329aaf31e7ab9f9e5db