### PR TITLE
Add managed cloud deployment reference for Neon and Upstash

### DIFF
--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -1,0 +1,107 @@
+# Cloud Deployment Guide
+
+This guide provides a reference architecture for deploying Plane with managed data services (Neon Postgres and Upstash Redis) and a container runtime (Render or Railway) while keeping the existing product interface unchanged. All configuration is additive, so you can introduce it without conflicting with ongoing self-hosted work.
+
+## Overview
+
+The recommended topology keeps the Plane application stack in Docker Compose while delegating stateful services to managed providers:
+
+- **Database**: Neon serverless Postgres
+- **Cache / Queue**: Upstash Redis
+- **Application Runtime**: Render or Railway hosting a Docker Compose workload
+- **Object Storage**: Continue using the S3-compatible bucket already configured in your environment (no change needed for compatibility).
+
+The Compose definition exposes the same ports, environment variables, and container names that the self-hosted bundle uses to guarantee interface parity.
+
+## Prerequisites
+
+1. Plane repository cloned with access to `deploy/` assets.
+2. Docker and Docker Compose plugin available locally for build and testing.
+3. Accounts created at [Neon](https://neon.tech/), [Upstash](https://upstash.com/), and either [Render](https://render.com/) or [Railway](https://railway.app/).
+4. Existing Plane `.env` secrets stored in a secure secret manager (Render/Railway environment variables, or a GitHub Actions secret for automation).
+
+## Step 1 – Provision managed services
+
+### Neon Postgres
+
+1. Create a new project and database branch.
+2. Set the region closest to your application runtime.
+3. Copy the Postgres connection string in the "psql" format.
+4. Enforce connection pooling (pgBouncer) with the same database, user, and password values used locally.
+
+### Upstash Redis
+
+1. Create a new Redis database.
+2. Select the serverless plan that matches your load profile.
+3. Copy the REST URL, REST token, and TLS-enabled Redis URL.
+4. Enable multi-region replication if you expect a globally distributed workload.
+
+Store these secrets securely for later use as Compose environment variables.
+
+## Step 2 – Prepare the Docker Compose workload
+
+A dedicated Compose file keeps settings aligned with the published self-host bundle while externalizing data stores. See [`docker-compose.managed.yml`](./docker-compose.managed.yml) for the reference configuration. Key updates:
+
+- Removes bundled Postgres and Redis containers.
+- Injects Neon/Upstash URLs through environment variables (`DATABASE_URL`, `REDIS_URL`, `REDIS_REST_URL`, `REDIS_REST_TOKEN`).
+- Adds health checks so Render/Railway can monitor service status.
+
+You can validate the configuration locally:
+
+```bash
+docker compose -f deploy/cloud/docker-compose.managed.yml --env-file deploy/selfhost/variables.env up --build
+```
+
+Stop the stack with `docker compose ... down` when finished.
+
+## Step 3 – Deploy on Render
+
+1. Create a new **Blueprint** service.
+2. Point Render to your repository and select the `deploy/cloud` directory as the blueprint root.
+3. Set the following environment variables in the Render dashboard (use Neon/Upstash values):
+   - `DATABASE_URL`
+   - `REDIS_URL`
+   - `REDIS_REST_URL`
+   - `REDIS_REST_TOKEN`
+   - Any other secrets listed in `deploy/selfhost/variables.env`
+4. Enable auto-deploy on git push and configure health checks:
+   - HTTP health check on `https://<your-domain>/api/health/`
+   - Background worker health checks rely on Compose `healthcheck` definitions.
+
+Render will build the Docker images using the provided Dockerfile contexts. Keep an eye on the Render Activity feed for build logs.
+
+## Step 4 – Deploy on Railway
+
+Railway offers a similar flow using the Compose plugin:
+
+1. Install the Railway CLI and log in: `npm i -g @railway/cli && railway login`.
+2. Initialize a new project with Docker support: `railway init --plugins docker`.
+3. Push the Compose file: `railway up --service plane --docker-compose deploy/cloud/docker-compose.managed.yml`.
+4. Set the required environment variables in the Railway dashboard or via `railway variables set`.
+5. Configure metrics and logging in Railway's observability tab for ongoing monitoring.
+
+## Step 5 – Monitor and alert
+
+Monitoring on Render or Railway relies on provider integrations:
+
+- **Metrics**: Enable CPU, memory, and response-time dashboards. Set thresholds based on your current self-hosted utilization.
+- **Logs**: Stream application logs to a centralized destination (Render Log Streams, Railway Observability, or an external provider like Datadog).
+- **Health checks**: Ensure the `/api/health/` endpoint returns HTTP 200. Compose health checks restart unhealthy containers automatically.
+- **Alerts**: Configure alerts for deploy failures, container restarts, and sustained high latency. Both Render and Railway support Slack, email, and webhook notifications.
+
+For deeper application monitoring, integrate OpenTelemetry exporters already available in the Plane stack. Point them to your observability backend (Tempo, Honeycomb, etc.) by extending environment variables in the Compose file.
+
+## Rollback plan
+
+1. Keep the existing self-hosted stack running until the managed deployment passes all checks.
+2. Use database branching in Neon to revert to a previous snapshot if a migration fails.
+3. Enable Redis persistence in Upstash and clone the database to recover from cache corruption.
+4. Maintain a backup copy of `docker-compose.managed.yml` and `.env` secrets in version control with restricted access.
+
+## Next steps
+
+- Automate migrations using Render/Railway deployment hooks (`./deploy/selfhost/install.sh migrate`).
+- Add synthetic monitoring via Checkly or Grafana Cloud to detect regressions.
+- Update runbooks with the new managed-service topology.
+
+Following this process gives you enterprise-grade reliability while keeping the Plane interface and behaviour untouched.

--- a/deploy/cloud/docker-compose.managed.yml
+++ b/deploy/cloud/docker-compose.managed.yml
@@ -1,0 +1,208 @@
+version: "3.9"
+
+x-db-env: &db-env
+  DATABASE_URL: ${DATABASE_URL}
+  PGHOST: ${PGHOST:-}
+  PGDATABASE: ${PGDATABASE:-}
+  POSTGRES_USER: ${POSTGRES_USER:-}
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
+  POSTGRES_DB: ${POSTGRES_DB:-}
+  POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+
+x-redis-env: &redis-env
+  REDIS_URL: ${REDIS_URL}
+  REDIS_REST_URL: ${REDIS_REST_URL:-}
+  REDIS_REST_TOKEN: ${REDIS_REST_TOKEN:-}
+
+x-minio-env: &minio-env
+  MINIO_ROOT_USER: ${AWS_ACCESS_KEY_ID:-}
+  MINIO_ROOT_PASSWORD: ${AWS_SECRET_ACCESS_KEY:-}
+
+x-aws-s3-env: &aws-s3-env
+  AWS_REGION: ${AWS_REGION:-}
+  AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+  AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+  AWS_S3_ENDPOINT_URL: ${AWS_S3_ENDPOINT_URL:-}
+  AWS_S3_BUCKET_NAME: ${AWS_S3_BUCKET_NAME:-}
+
+x-proxy-env: &proxy-env
+  SSL: ${SSL:-false}
+  APP_DOMAIN: ${APP_DOMAIN:-localhost}
+  FILE_SIZE_LIMIT: ${FILE_SIZE_LIMIT:-5242880}
+  CERT_EMAIL: ${CERT_EMAIL:-}
+  CERT_ACME_CA: ${CERT_ACME_CA:-}
+  CERT_ACME_DNS: ${CERT_ACME_DNS:-}
+  LISTEN_HTTP_PORT: ${LISTEN_PORT:-80}
+  LISTEN_HTTPS_PORT: ${LISTEN_SSL_PORT:-443}
+  BUCKET_NAME: ${AWS_S3_BUCKET_NAME:-uploads}
+  SITE_ADDRESS: ${SITE_ADDRESS:-:80}
+
+x-mq-env: &mq-env
+  RABBITMQ_HOST: ${RABBITMQ_HOST:-plane-mq}
+  RABBITMQ_PORT: ${RABBITMQ_PORT:-5672}
+  RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-plane}
+  RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:-plane}
+  RABBITMQ_DEFAULT_VHOST: ${RABBITMQ_VHOST:-plane}
+  RABBITMQ_VHOST: ${RABBITMQ_VHOST:-plane}
+
+x-live-env: &live-env
+  API_BASE_URL: ${API_BASE_URL:-http://api:8000}
+
+x-app-env: &app-env
+  WEB_URL: ${WEB_URL:-http://localhost}
+  DEBUG: ${DEBUG:-0}
+  CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+  GUNICORN_WORKERS: 1
+  USE_MINIO: ${USE_MINIO:-1}
+  SECRET_KEY: ${SECRET_KEY:-}
+  AMQP_URL: ${AMQP_URL:-amqp://plane:plane@plane-mq:5672/plane}
+  API_KEY_RATE_LIMIT: ${API_KEY_RATE_LIMIT:-60/minute}
+  MINIO_ENDPOINT_SSL: ${MINIO_ENDPOINT_SSL:-0}
+
+services:
+  web:
+    image: artifacts.plane.so/makeplane/plane-frontend:${APP_RELEASE:-stable}
+    command: node web/server.js web
+    deploy:
+      replicas: ${WEB_REPLICAS:-1}
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      api:
+        condition: service_healthy
+      worker:
+        condition: service_started
+
+  space:
+    image: artifacts.plane.so/makeplane/plane-space:${APP_RELEASE:-stable}
+    command: node space/server.js space
+    deploy:
+      replicas: ${SPACE_REPLICAS:-1}
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      api:
+        condition: service_healthy
+      worker:
+        condition: service_started
+      web:
+        condition: service_started
+
+  admin:
+    image: artifacts.plane.so/makeplane/plane-admin:${APP_RELEASE:-stable}
+    command: node admin/server.js admin
+    deploy:
+      replicas: ${ADMIN_REPLICAS:-1}
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      api:
+        condition: service_healthy
+      web:
+        condition: service_started
+
+  live:
+    image: artifacts.plane.so/makeplane/plane-live:${APP_RELEASE:-stable}
+    command: node live/dist/server.js live
+    environment:
+      <<: [*live-env]
+    deploy:
+      replicas: ${LIVE_REPLICAS:-1}
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      api:
+        condition: service_healthy
+      web:
+        condition: service_started
+
+  api:
+    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
+    command: ./bin/docker-entrypoint-api.sh
+    deploy:
+      replicas: ${API_REPLICAS:-1}
+      restart_policy:
+        condition: on-failure
+    volumes:
+      - logs_api:/code/plane/logs
+    environment:
+      <<: [*app-env, *db-env, *redis-env, *minio-env, *aws-s3-env, *proxy-env]
+    depends_on:
+      plane-mq:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/health/"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  worker:
+    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
+    command: ./bin/docker-entrypoint-worker.sh
+    deploy:
+      replicas: ${WORKER_REPLICAS:-1}
+      restart_policy:
+        condition: on-failure
+    volumes:
+      - logs_worker:/code/plane/logs
+    environment:
+      <<: [*app-env, *db-env, *redis-env, *minio-env, *aws-s3-env, *proxy-env]
+    depends_on:
+      api:
+        condition: service_healthy
+      plane-mq:
+        condition: service_healthy
+
+  beat-worker:
+    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
+    command: ./bin/docker-entrypoint-beat.sh
+    deploy:
+      replicas: ${BEAT_WORKER_REPLICAS:-1}
+      restart_policy:
+        condition: on-failure
+    volumes:
+      - logs_beat-worker:/code/plane/logs
+    environment:
+      <<: [*app-env, *db-env, *redis-env, *minio-env, *aws-s3-env, *proxy-env]
+    depends_on:
+      api:
+        condition: service_healthy
+      plane-mq:
+        condition: service_healthy
+
+  plane-mq:
+    image: rabbitmq:3.12-management
+    environment:
+      <<: [*mq-env]
+    volumes:
+      - plane_mq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "check_running"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  plane-proxy:
+    image: artifacts.plane.so/makeplane/plane-proxy:${APP_RELEASE:-stable}
+    environment:
+      <<: [*proxy-env, *aws-s3-env]
+    ports:
+      - "${LISTEN_PORT:-80}:${LISTEN_PORT:-80}"
+      - "${LISTEN_SSL_PORT:-443}:${LISTEN_SSL_PORT:-443}"
+    depends_on:
+      web:
+        condition: service_started
+      space:
+        condition: service_started
+      admin:
+        condition: service_started
+      live:
+        condition: service_started
+
+volumes:
+  logs_api:
+  logs_worker:
+  logs_beat-worker:
+  plane_mq_data:


### PR DESCRIPTION
## Summary
- add a cloud deployment guide covering Neon Postgres, Upstash Redis, and Render/Railway workflows
- provide a managed Docker Compose definition that preserves the existing service interface while using hosted data stores

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d749fef3d0832982ab5bfca60faa5a