### PR TITLE
Add SendGrid-aware SMTP configuration

### DIFF
--- a/apps/api/plane/authentication/provider/credentials/magic_code.py
+++ b/apps/api/plane/authentication/provider/credentials/magic_code.py
@@ -7,6 +7,7 @@ import string
 
 # Module imports
 from plane.authentication.adapter.credential import CredentialAdapter
+from plane.license.utils.email_config import is_smtp_configured
 from plane.license.utils.instance_value import get_configuration_value
 from plane.settings.redis import redis_instance
 from plane.authentication.adapter.error import (
@@ -20,17 +21,25 @@ class MagicCodeProvider(CredentialAdapter):
     provider = "magic-code"
 
     def __init__(self, request, key, code=None, callback=None):
-        (EMAIL_HOST, ENABLE_MAGIC_LINK_LOGIN) = get_configuration_value(
+        (
+            EMAIL_HOST,
+            ENABLE_MAGIC_LINK_LOGIN,
+            SENDGRID_API_KEY,
+        ) = get_configuration_value(
             [
                 {"key": "EMAIL_HOST", "default": os.environ.get("EMAIL_HOST")},
                 {
                     "key": "ENABLE_MAGIC_LINK_LOGIN",
                     "default": os.environ.get("ENABLE_MAGIC_LINK_LOGIN", "1"),
                 },
+                {
+                    "key": "SENDGRID_API_KEY",
+                    "default": os.environ.get("SENDGRID_API_KEY", ""),
+                },
             ]
         )
 
-        if not (EMAIL_HOST):
+        if not is_smtp_configured(EMAIL_HOST, SENDGRID_API_KEY):
             raise AuthenticationException(
                 error_code=AUTHENTICATION_ERROR_CODES["SMTP_NOT_CONFIGURED"],
                 error_message="SMTP_NOT_CONFIGURED",

--- a/apps/api/plane/authentication/views/app/check.py
+++ b/apps/api/plane/authentication/views/app/check.py
@@ -19,6 +19,7 @@ from plane.authentication.adapter.error import (
     AUTHENTICATION_ERROR_CODES,
 )
 from plane.authentication.rate_limit import AuthenticationThrottle
+from plane.license.utils.email_config import is_smtp_configured
 from plane.license.utils.instance_value import get_configuration_value
 
 
@@ -37,17 +38,21 @@ class EmailCheckEndpoint(APIView):
             )
             return Response(exc.get_error_dict(), status=status.HTTP_400_BAD_REQUEST)
 
-        (EMAIL_HOST, ENABLE_MAGIC_LINK_LOGIN) = get_configuration_value(
+        (EMAIL_HOST, ENABLE_MAGIC_LINK_LOGIN, SENDGRID_API_KEY) = get_configuration_value(
             [
                 {"key": "EMAIL_HOST", "default": os.environ.get("EMAIL_HOST", "")},
                 {
                     "key": "ENABLE_MAGIC_LINK_LOGIN",
                     "default": os.environ.get("ENABLE_MAGIC_LINK_LOGIN", "1"),
                 },
+                {
+                    "key": "SENDGRID_API_KEY",
+                    "default": os.environ.get("SENDGRID_API_KEY", ""),
+                },
             ]
         )
 
-        smtp_configured = bool(EMAIL_HOST)
+        smtp_configured = is_smtp_configured(EMAIL_HOST, SENDGRID_API_KEY)
         is_magic_login_enabled = ENABLE_MAGIC_LINK_LOGIN == "1"
 
         email = request.data.get("email", False)

--- a/apps/api/plane/authentication/views/app/password_management.py
+++ b/apps/api/plane/authentication/views/app/password_management.py
@@ -22,6 +22,7 @@ from django.views import View
 from plane.bgtasks.forgot_password_task import forgot_password
 from plane.license.models import Instance
 from plane.db.models import User
+from plane.license.utils.email_config import is_smtp_configured
 from plane.license.utils.instance_value import get_configuration_value
 from plane.authentication.utils.host import base_host
 from plane.authentication.adapter.error import (
@@ -55,11 +56,17 @@ class ForgotPasswordEndpoint(APIView):
             )
             return Response(exc.get_error_dict(), status=status.HTTP_400_BAD_REQUEST)
 
-        (EMAIL_HOST,) = get_configuration_value(
-            [{"key": "EMAIL_HOST", "default": os.environ.get("EMAIL_HOST")}]
+        (EMAIL_HOST, SENDGRID_API_KEY) = get_configuration_value(
+            [
+                {"key": "EMAIL_HOST", "default": os.environ.get("EMAIL_HOST")},
+                {
+                    "key": "SENDGRID_API_KEY",
+                    "default": os.environ.get("SENDGRID_API_KEY", ""),
+                },
+            ]
         )
 
-        if not (EMAIL_HOST):
+        if not is_smtp_configured(EMAIL_HOST, SENDGRID_API_KEY):
             exc = AuthenticationException(
                 error_message="SMTP_NOT_CONFIGURED",
                 error_code=AUTHENTICATION_ERROR_CODES["SMTP_NOT_CONFIGURED"],

--- a/apps/api/plane/authentication/views/space/check.py
+++ b/apps/api/plane/authentication/views/space/check.py
@@ -19,6 +19,7 @@ from plane.authentication.adapter.error import (
     AuthenticationException,
 )
 from plane.authentication.rate_limit import AuthenticationThrottle
+from plane.license.utils.email_config import is_smtp_configured
 from plane.license.utils.instance_value import get_configuration_value
 
 
@@ -37,17 +38,21 @@ class EmailCheckSpaceEndpoint(APIView):
             )
             return Response(exc.get_error_dict(), status=status.HTTP_400_BAD_REQUEST)
 
-        (EMAIL_HOST, ENABLE_MAGIC_LINK_LOGIN) = get_configuration_value(
+        (EMAIL_HOST, ENABLE_MAGIC_LINK_LOGIN, SENDGRID_API_KEY) = get_configuration_value(
             [
                 {"key": "EMAIL_HOST", "default": os.environ.get("EMAIL_HOST", "")},
                 {
                     "key": "ENABLE_MAGIC_LINK_LOGIN",
                     "default": os.environ.get("ENABLE_MAGIC_LINK_LOGIN", "1"),
                 },
+                {
+                    "key": "SENDGRID_API_KEY",
+                    "default": os.environ.get("SENDGRID_API_KEY", ""),
+                },
             ]
         )
 
-        smtp_configured = bool(EMAIL_HOST)
+        smtp_configured = is_smtp_configured(EMAIL_HOST, SENDGRID_API_KEY)
         is_magic_login_enabled = ENABLE_MAGIC_LINK_LOGIN == "1"
 
         email = request.data.get("email", False)

--- a/apps/api/plane/authentication/views/space/password_management.py
+++ b/apps/api/plane/authentication/views/space/password_management.py
@@ -22,6 +22,7 @@ from django.views import View
 from plane.bgtasks.forgot_password_task import forgot_password
 from plane.license.models import Instance
 from plane.db.models import User
+from plane.license.utils.email_config import is_smtp_configured
 from plane.license.utils.instance_value import get_configuration_value
 from plane.authentication.utils.host import base_host
 from plane.authentication.adapter.error import (
@@ -55,7 +56,12 @@ class ForgotPasswordSpaceEndpoint(APIView):
             )
             return Response(exc.get_error_dict(), status=status.HTTP_400_BAD_REQUEST)
 
-        (EMAIL_HOST, EMAIL_HOST_USER, EMAIL_HOST_PASSWORD) = get_configuration_value(
+        (
+            EMAIL_HOST,
+            EMAIL_HOST_USER,
+            EMAIL_HOST_PASSWORD,
+            SENDGRID_API_KEY,
+        ) = get_configuration_value(
             [
                 {"key": "EMAIL_HOST", "default": os.environ.get("EMAIL_HOST")},
                 {
@@ -66,10 +72,14 @@ class ForgotPasswordSpaceEndpoint(APIView):
                     "key": "EMAIL_HOST_PASSWORD",
                     "default": os.environ.get("EMAIL_HOST_PASSWORD"),
                 },
+                {
+                    "key": "SENDGRID_API_KEY",
+                    "default": os.environ.get("SENDGRID_API_KEY", ""),
+                },
             ]
         )
 
-        if not (EMAIL_HOST):
+        if not is_smtp_configured(EMAIL_HOST, SENDGRID_API_KEY):
             exc = AuthenticationException(
                 error_message="SMTP_NOT_CONFIGURED",
                 error_code=AUTHENTICATION_ERROR_CODES["SMTP_NOT_CONFIGURED"],

--- a/apps/api/plane/license/api/views/instance.py
+++ b/apps/api/plane/license/api/views/instance.py
@@ -15,6 +15,7 @@ from plane.db.models import Workspace
 from plane.license.api.permissions import InstanceAdminPermission
 from plane.license.api.serializers import InstanceSerializer
 from plane.license.models import Instance
+from plane.license.utils.email_config import is_smtp_configured
 from plane.license.utils.instance_value import get_configuration_value
 from plane.utils.cache import cache_response, invalidate_cache
 from django.utils.decorators import method_decorator
@@ -60,6 +61,7 @@ class InstanceEndpoint(BaseAPIView):
             LLM_API_KEY,
             IS_INTERCOM_ENABLED,
             INTERCOM_APP_ID,
+            SENDGRID_API_KEY,
         ) = get_configuration_value(
             [
                 {
@@ -124,6 +126,10 @@ class InstanceEndpoint(BaseAPIView):
                     "key": "INTERCOM_APP_ID",
                     "default": os.environ.get("INTERCOM_APP_ID", ""),
                 },
+                {
+                    "key": "SENDGRID_API_KEY",
+                    "default": os.environ.get("SENDGRID_API_KEY", ""),
+                },
             ]
         )
 
@@ -157,7 +163,9 @@ class InstanceEndpoint(BaseAPIView):
         data["file_size_limit"] = float(os.environ.get("FILE_SIZE_LIMIT", 5242880))
 
         # is smtp configured
-        data["is_smtp_configured"] = bool(EMAIL_HOST)
+        data["is_smtp_configured"] = is_smtp_configured(
+            EMAIL_HOST, SENDGRID_API_KEY
+        )
 
         # Intercom settings
         data["is_intercom_enabled"] = IS_INTERCOM_ENABLED == "1"

--- a/apps/api/plane/license/management/commands/configure_instance.py
+++ b/apps/api/plane/license/management/commands/configure_instance.py
@@ -6,6 +6,11 @@ from django.core.management.base import BaseCommand, CommandError
 
 # Module imports
 from plane.license.models import InstanceConfiguration
+from plane.license.utils.email_config import (
+    DEFAULT_SMTP_PORT,
+    SENDGRID_DEFAULT_HOST,
+    SENDGRID_DEFAULT_USERNAME,
+)
 
 
 class Command(BaseCommand):
@@ -134,6 +139,56 @@ class Command(BaseCommand):
             {
                 "key": "EMAIL_USE_SSL",
                 "value": os.environ.get("EMAIL_USE_SSL", "0"),
+                "category": "SMTP",
+                "is_encrypted": False,
+            },
+            {
+                "key": "SENDGRID_API_KEY",
+                "value": os.environ.get("SENDGRID_API_KEY", ""),
+                "category": "SMTP",
+                "is_encrypted": True,
+            },
+            {
+                "key": "SENDGRID_SMTP_HOST",
+                "value": os.environ.get(
+                    "SENDGRID_SMTP_HOST", SENDGRID_DEFAULT_HOST
+                ),
+                "category": "SMTP",
+                "is_encrypted": False,
+            },
+            {
+                "key": "SENDGRID_SMTP_PORT",
+                "value": os.environ.get(
+                    "SENDGRID_SMTP_PORT", str(DEFAULT_SMTP_PORT)
+                ),
+                "category": "SMTP",
+                "is_encrypted": False,
+            },
+            {
+                "key": "SENDGRID_SMTP_USERNAME",
+                "value": os.environ.get(
+                    "SENDGRID_SMTP_USERNAME", SENDGRID_DEFAULT_USERNAME
+                ),
+                "category": "SMTP",
+                "is_encrypted": False,
+            },
+            {
+                "key": "SENDGRID_SMTP_USE_TLS",
+                "value": os.environ.get("SENDGRID_SMTP_USE_TLS", "1"),
+                "category": "SMTP",
+                "is_encrypted": False,
+            },
+            {
+                "key": "SENDGRID_SMTP_USE_SSL",
+                "value": os.environ.get("SENDGRID_SMTP_USE_SSL", "0"),
+                "category": "SMTP",
+                "is_encrypted": False,
+            },
+            {
+                "key": "SENDGRID_FROM_EMAIL",
+                "value": os.environ.get(
+                    "SENDGRID_FROM_EMAIL", os.environ.get("EMAIL_FROM", "")
+                ),
                 "category": "SMTP",
                 "is_encrypted": False,
             },

--- a/apps/api/plane/license/utils/email_config.py
+++ b/apps/api/plane/license/utils/email_config.py
@@ -1,0 +1,129 @@
+"""Utilities for resolving SMTP configuration values."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+DEFAULT_FROM_EMAIL = "Team Plane <team@mailer.plane.so>"
+DEFAULT_SMTP_PORT = 587
+SENDGRID_DEFAULT_HOST = "smtp.sendgrid.net"
+SENDGRID_DEFAULT_USERNAME = "apikey"
+
+logger = logging.getLogger("plane.license.email")
+_SENDGRID_LOGGED = False
+
+
+def _clean_str(value: Optional[object]) -> str:
+    """Return a trimmed string representation of value or an empty string."""
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _normalize_flag(value: Optional[str], default: str) -> str:
+    """Ensure boolean-like string values are coerced to "0" or "1"."""
+    cleaned = _clean_str(value)
+    if cleaned in {"0", "1"}:
+        return cleaned
+    return default
+
+
+def _normalize_port(value: Optional[object]) -> str:
+    """Normalize the SMTP port to a non-empty string."""
+    cleaned = _clean_str(value)
+    return cleaned or str(DEFAULT_SMTP_PORT)
+
+
+@dataclass
+class EmailConfig:
+    """Represents the primary SMTP configuration."""
+
+    host: Optional[str] = None
+    username: Optional[str] = None
+    password: Optional[str] = None
+    port: Optional[object] = None
+    use_tls: Optional[str] = None
+    use_ssl: Optional[str] = None
+    from_email: Optional[str] = None
+
+    def as_tuple(self) -> Tuple[str, str, str, str, str, str, str]:
+        """Return the configuration as a tuple expected by legacy callers."""
+        return (
+            _clean_str(self.host),
+            _clean_str(self.username),
+            _clean_str(self.password),
+            _normalize_port(self.port),
+            _normalize_flag(self.use_tls, "1"),
+            _normalize_flag(self.use_ssl, "0"),
+            _clean_str(self.from_email) or DEFAULT_FROM_EMAIL,
+        )
+
+
+@dataclass
+class SendGridSettings:
+    """Represents optional SendGrid SMTP configuration overrides."""
+
+    api_key: Optional[str] = None
+    host: Optional[str] = None
+    port: Optional[object] = None
+    username: Optional[str] = None
+    use_tls: Optional[str] = None
+    use_ssl: Optional[str] = None
+    from_email: Optional[str] = None
+
+    def is_configured(self) -> bool:
+        return bool(_clean_str(self.api_key))
+
+
+def apply_sendgrid_overrides(base: EmailConfig, sendgrid: SendGridSettings) -> EmailConfig:
+    """Populate empty SMTP values from SendGrid configuration when available."""
+    if _clean_str(base.host):
+        return base
+
+    if not sendgrid.is_configured():
+        return base
+
+    global _SENDGRID_LOGGED
+    if not _SENDGRID_LOGGED:
+        logger.info("Falling back to SendGrid SMTP configuration for outbound email.")
+        _SENDGRID_LOGGED = True
+
+    base.host = _clean_str(sendgrid.host) or SENDGRID_DEFAULT_HOST
+    base.username = _clean_str(sendgrid.username) or SENDGRID_DEFAULT_USERNAME
+    base.password = _clean_str(sendgrid.api_key)
+    base.port = (
+        _normalize_port(sendgrid.port)
+        if _clean_str(sendgrid.port)
+        else _normalize_port(base.port)
+    )
+    # Prioritise explicit SendGrid flags, otherwise respect existing configuration.
+    base.use_tls = _normalize_flag(
+        sendgrid.use_tls, _normalize_flag(base.use_tls, "1")
+    )
+    base.use_ssl = _normalize_flag(
+        sendgrid.use_ssl, _normalize_flag(base.use_ssl, "0")
+    )
+
+    current_from_email = _clean_str(base.from_email)
+    if not current_from_email or current_from_email == DEFAULT_FROM_EMAIL:
+        base.from_email = _clean_str(sendgrid.from_email) or current_from_email
+
+    return base
+
+
+def is_smtp_configured(host: Optional[str], sendgrid_api_key: Optional[str]) -> bool:
+    """Return True when SMTP credentials are present via host or SendGrid API key."""
+    return bool(_clean_str(host)) or bool(_clean_str(sendgrid_api_key))
+
+
+__all__ = [
+    "DEFAULT_FROM_EMAIL",
+    "DEFAULT_SMTP_PORT",
+    "SENDGRID_DEFAULT_HOST",
+    "SENDGRID_DEFAULT_USERNAME",
+    "EmailConfig",
+    "SendGridSettings",
+    "apply_sendgrid_overrides",
+    "is_smtp_configured",
+]

--- a/apps/api/plane/license/utils/instance_value.py
+++ b/apps/api/plane/license/utils/instance_value.py
@@ -7,6 +7,14 @@ from django.conf import settings
 # Module imports
 from plane.license.models import InstanceConfiguration
 from plane.license.utils.encryption import decrypt_data
+from plane.license.utils.email_config import (
+    DEFAULT_SMTP_PORT,
+    EmailConfig,
+    SendGridSettings,
+    SENDGRID_DEFAULT_HOST,
+    SENDGRID_DEFAULT_USERNAME,
+    apply_sendgrid_overrides,
+)
 
 
 # Helper function to return value from the passed key
@@ -38,15 +46,36 @@ def get_configuration_value(keys):
 
 
 def get_email_configuration():
-    return get_configuration_value(
+    (
+        email_host,
+        email_host_user,
+        email_host_password,
+        email_port,
+        email_use_tls,
+        email_use_ssl,
+        email_from,
+        sendgrid_api_key,
+        sendgrid_host,
+        sendgrid_port,
+        sendgrid_username,
+        sendgrid_use_tls,
+        sendgrid_use_ssl,
+        sendgrid_from_email,
+    ) = get_configuration_value(
         [
             {"key": "EMAIL_HOST", "default": os.environ.get("EMAIL_HOST")},
-            {"key": "EMAIL_HOST_USER", "default": os.environ.get("EMAIL_HOST_USER")},
+            {
+                "key": "EMAIL_HOST_USER",
+                "default": os.environ.get("EMAIL_HOST_USER"),
+            },
             {
                 "key": "EMAIL_HOST_PASSWORD",
                 "default": os.environ.get("EMAIL_HOST_PASSWORD"),
             },
-            {"key": "EMAIL_PORT", "default": os.environ.get("EMAIL_PORT", 587)},
+            {
+                "key": "EMAIL_PORT",
+                "default": os.environ.get("EMAIL_PORT", DEFAULT_SMTP_PORT),
+            },
             {"key": "EMAIL_USE_TLS", "default": os.environ.get("EMAIL_USE_TLS", "1")},
             {"key": "EMAIL_USE_SSL", "default": os.environ.get("EMAIL_USE_SSL", "0")},
             {
@@ -55,5 +84,60 @@ def get_email_configuration():
                     "EMAIL_FROM", "Team Plane <team@mailer.plane.so>"
                 ),
             },
+            {
+                "key": "SENDGRID_API_KEY",
+                "default": os.environ.get("SENDGRID_API_KEY"),
+            },
+            {
+                "key": "SENDGRID_SMTP_HOST",
+                "default": os.environ.get(
+                    "SENDGRID_SMTP_HOST", SENDGRID_DEFAULT_HOST
+                ),
+            },
+            {
+                "key": "SENDGRID_SMTP_PORT",
+                "default": os.environ.get("SENDGRID_SMTP_PORT", DEFAULT_SMTP_PORT),
+            },
+            {
+                "key": "SENDGRID_SMTP_USERNAME",
+                "default": os.environ.get(
+                    "SENDGRID_SMTP_USERNAME", SENDGRID_DEFAULT_USERNAME
+                ),
+            },
+            {
+                "key": "SENDGRID_SMTP_USE_TLS",
+                "default": os.environ.get("SENDGRID_SMTP_USE_TLS", "1"),
+            },
+            {
+                "key": "SENDGRID_SMTP_USE_SSL",
+                "default": os.environ.get("SENDGRID_SMTP_USE_SSL", "0"),
+            },
+            {
+                "key": "SENDGRID_FROM_EMAIL",
+                "default": os.environ.get("SENDGRID_FROM_EMAIL"),
+            },
         ]
     )
+
+    base_config = EmailConfig(
+        host=email_host,
+        username=email_host_user,
+        password=email_host_password,
+        port=email_port,
+        use_tls=email_use_tls,
+        use_ssl=email_use_ssl,
+        from_email=email_from,
+    )
+
+    sendgrid_settings = SendGridSettings(
+        api_key=sendgrid_api_key,
+        host=sendgrid_host,
+        port=sendgrid_port,
+        username=sendgrid_username,
+        use_tls=sendgrid_use_tls,
+        use_ssl=sendgrid_use_ssl,
+        from_email=sendgrid_from_email,
+    )
+
+    resolved_config = apply_sendgrid_overrides(base_config, sendgrid_settings)
+    return resolved_config.as_tuple()

--- a/apps/api/plane/tests/unit/utils/test_email_configuration.py
+++ b/apps/api/plane/tests/unit/utils/test_email_configuration.py
@@ -1,0 +1,97 @@
+import pytest
+from django.test import override_settings
+
+from plane.license.utils.email_config import (
+    DEFAULT_SMTP_PORT,
+    SENDGRID_DEFAULT_HOST,
+    SENDGRID_DEFAULT_USERNAME,
+    is_smtp_configured,
+)
+from plane.license.utils.instance_value import get_email_configuration
+
+EMAIL_ENV_KEYS = [
+    "EMAIL_HOST",
+    "EMAIL_HOST_USER",
+    "EMAIL_HOST_PASSWORD",
+    "EMAIL_PORT",
+    "EMAIL_USE_TLS",
+    "EMAIL_USE_SSL",
+    "EMAIL_FROM",
+    "SENDGRID_API_KEY",
+    "SENDGRID_SMTP_HOST",
+    "SENDGRID_SMTP_PORT",
+    "SENDGRID_SMTP_USERNAME",
+    "SENDGRID_SMTP_USE_TLS",
+    "SENDGRID_SMTP_USE_SSL",
+    "SENDGRID_FROM_EMAIL",
+]
+
+
+@pytest.fixture(autouse=True)
+def clear_email_environment(monkeypatch):
+    for key in EMAIL_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    yield
+
+
+@pytest.fixture
+def use_env_settings():
+    with override_settings(SKIP_ENV_VAR=False):
+        yield
+
+
+def test_get_email_configuration_prefers_explicit_settings(monkeypatch, use_env_settings):
+    monkeypatch.setenv("EMAIL_HOST", "smtp.example.com")
+    monkeypatch.setenv("EMAIL_HOST_USER", "admin")
+    monkeypatch.setenv("EMAIL_HOST_PASSWORD", "secret")
+    monkeypatch.setenv("EMAIL_PORT", "2525")
+    monkeypatch.setenv("EMAIL_USE_TLS", "0")
+    monkeypatch.setenv("EMAIL_USE_SSL", "1")
+    monkeypatch.setenv("EMAIL_FROM", "Plane <plane@example.com>")
+    monkeypatch.setenv("SENDGRID_API_KEY", "SG.fake-key")
+
+    config = get_email_configuration()
+
+    assert config == (
+        "smtp.example.com",
+        "admin",
+        "secret",
+        "2525",
+        "0",
+        "1",
+        "Plane <plane@example.com>",
+    )
+
+
+def test_get_email_configuration_falls_back_to_sendgrid(monkeypatch, use_env_settings):
+    monkeypatch.setenv("SENDGRID_API_KEY", "SG.sendgrid")
+    monkeypatch.setenv("SENDGRID_FROM_EMAIL", "no-reply@example.com")
+
+    config = get_email_configuration()
+
+    assert config[0] == SENDGRID_DEFAULT_HOST
+    assert config[1] == SENDGRID_DEFAULT_USERNAME
+    assert config[2] == "SG.sendgrid"
+    assert config[3] == str(DEFAULT_SMTP_PORT)
+    assert config[4] == "1"
+    assert config[5] == "0"
+    assert config[6] == "no-reply@example.com"
+
+
+def test_get_email_configuration_respects_sendgrid_overrides(monkeypatch, use_env_settings):
+    monkeypatch.setenv("SENDGRID_API_KEY", "SG.override")
+    monkeypatch.setenv("SENDGRID_SMTP_PORT", "465")
+    monkeypatch.setenv("SENDGRID_SMTP_USE_TLS", "0")
+    monkeypatch.setenv("SENDGRID_SMTP_USE_SSL", "1")
+
+    config = get_email_configuration()
+
+    assert config[3] == "465"
+    assert config[4] == "0"
+    assert config[5] == "1"
+
+
+def test_is_smtp_configured_helper():
+    assert is_smtp_configured("smtp.example.com", "")
+    assert is_smtp_configured("", "SG.fake")
+    assert not is_smtp_configured("", "")

--- a/deploy/selfhost/README.md
+++ b/deploy/selfhost/README.md
@@ -152,6 +152,27 @@ Below are the most import keys you must refer to. _<span style="color: #fcba03">
 
 There are many other settings you can play with, but we suggest you configure `EMAIL SETTINGS` as it will enable you to invite your teammates onto the platform.
 
+#### Example: SendGrid SMTP configuration
+
+If you are using SendGrid, Plane can automatically fall back to the recommended SMTP settings as long as an API key is available. Add the following variables to your `plane.env` file:
+
+```
+SENDGRID_API_KEY=<your-sendgrid-api-key>
+SENDGRID_FROM_EMAIL=no-reply@example.com
+```
+
+Optional overrides are also supported:
+
+```
+SENDGRID_SMTP_HOST=smtp.sendgrid.net
+SENDGRID_SMTP_PORT=587
+SENDGRID_SMTP_USERNAME=apikey
+SENDGRID_SMTP_USE_TLS=1
+SENDGRID_SMTP_USE_SSL=0
+```
+
+You can continue to use the existing `EMAIL_HOST`, `EMAIL_HOST_USER`, and related variables if you prefer to manage the SMTP credentials manually—the SendGrid settings are only applied when the standard SMTP host is left blank.
+
 ---
 
 ### Continue with setup - Start Server (Docker Compose)


### PR DESCRIPTION
## Summary
- add an email configuration utility that normalizes SMTP values and falls back to SendGrid credentials when the standard host is absent
- expand instance configuration, authentication guards, and management command support so SendGrid API keys count as SMTP setup and update the self-hosting guide with provider instructions
- cover the new behaviour with unit tests that exercise the SendGrid fallback logic

## Testing
- REDIS_URL=redis://localhost:6379/0 poetry run pytest plane/tests/unit/utils/test_email_configuration.py *(fails: ModuleNotFoundError: No module named 'pytest_django')*

------
https://chatgpt.com/codex/tasks/task_e_68d74a179e2483299abf8a80dfb6658f