### PR TITLE
Align API runtime with production infrastructure

### DIFF
--- a/apps/api/bin/docker-entrypoint-api.sh
+++ b/apps/api/bin/docker-entrypoint-api.sh
@@ -1,35 +1,29 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+
 python manage.py wait_for_db
-# Wait for migrations
 python manage.py wait_for_migrations
 
-# Create the default bucket
-#!/bin/bash
-
-# Collect system information
+# Collect system information to build a deterministic machine signature
 HOSTNAME=$(hostname)
 MAC_ADDRESS=$(ip link show | awk '/ether/ {print $2}' | head -n 1)
 CPU_INFO=$(cat /proc/cpuinfo)
 MEMORY_INFO=$(free -h)
 DISK_INFO=$(df -h)
+SIGNATURE=$(echo "${HOSTNAME}${MAC_ADDRESS}${CPU_INFO}${MEMORY_INFO}${DISK_INFO}" | sha256sum | awk '{print $1}')
+export MACHINE_SIGNATURE=${SIGNATURE}
 
-# Concatenate information and compute SHA-256 hash
-SIGNATURE=$(echo "$HOSTNAME$MAC_ADDRESS$CPU_INFO$MEMORY_INFO$DISK_INFO" | sha256sum | awk '{print $1}')
-
-# Export the variables
-export MACHINE_SIGNATURE=$SIGNATURE
-
-# Register instance
-python manage.py register_instance "$MACHINE_SIGNATURE"
-
-# Load the configuration variable
+python manage.py register_instance "${MACHINE_SIGNATURE}"
 python manage.py configure_instance
-
-# Create the default bucket
 python manage.py create_bucket
 
-# Clear Cache before starting to remove stale values
 python manage.py clear_cache
+python manage.py collectstatic --noinput
 
-exec gunicorn -w "$GUNICORN_WORKERS" -k uvicorn.workers.UvicornWorker plane.asgi:application --bind 0.0.0.0:"${PORT:-8000}" --max-requests 1200 --max-requests-jitter 1000 --access-logfile -
+GUNICORN_WORKERS=${GUNICORN_WORKERS:-1}
+
+exec gunicorn -w "${GUNICORN_WORKERS}" -k uvicorn.workers.UvicornWorker plane.asgi:application \
+  --bind 0.0.0.0:"${PORT:-8000}" \
+  --max-requests 1200 \
+  --max-requests-jitter 1000 \
+  --access-logfile -

--- a/apps/api/bin/docker-entrypoint-beat.sh
+++ b/apps/api/bin/docker-entrypoint-beat.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 python manage.py wait_for_db
-# Wait for migrations
 python manage.py wait_for_migrations
-# Run the processes
-celery -A plane beat -l info
+
+exec celery -A plane beat -l info

--- a/apps/api/bin/docker-entrypoint-migrator.sh
+++ b/apps/api/bin/docker-entrypoint-migrator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-python manage.py wait_for_db $1
+python manage.py wait_for_db "$@"
 
-python manage.py migrate $1
+exec python manage.py migrate "$@"

--- a/apps/api/bin/docker-entrypoint-worker.sh
+++ b/apps/api/bin/docker-entrypoint-worker.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 python manage.py wait_for_db
-# Wait for migrations
 python manage.py wait_for_migrations
-# Run the processes
-celery -A plane worker -l info
+
+exec celery -A plane worker -l info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,11 +43,24 @@ services:
         DOCKER_BUILDKIT: 1
     restart: always
     command: ./bin/docker-entrypoint-api.sh
+    volumes:
+      - logs_api:/code/plane/logs
     env_file:
       - ./apps/api/.env
     depends_on:
       - plane-db
       - plane-redis
+      - plane-mq
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c 'import sys, urllib.request; urllib.request.urlopen(\"http://localhost:8000/api/health/\")'",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
 
   worker:
     container_name: bgworker
@@ -58,12 +71,15 @@ services:
         DOCKER_BUILDKIT: 1
     restart: always
     command: ./bin/docker-entrypoint-worker.sh
+    volumes:
+      - logs_worker:/code/plane/logs
     env_file:
       - ./apps/api/.env
     depends_on:
       - api
       - plane-db
       - plane-redis
+      - plane-mq
 
   beat-worker:
     container_name: beatworker
@@ -74,12 +90,15 @@ services:
         DOCKER_BUILDKIT: 1
     restart: always
     command: ./bin/docker-entrypoint-beat.sh
+    volumes:
+      - logs_beat_worker:/code/plane/logs
     env_file:
       - ./apps/api/.env
     depends_on:
       - api
       - plane-db
       - plane-redis
+      - plane-mq
 
   migrator:
     container_name: plane-migrator
@@ -90,11 +109,14 @@ services:
         DOCKER_BUILDKIT: 1
     restart: no
     command: ./bin/docker-entrypoint-migrator.sh
+    volumes:
+      - logs_migrator:/code/plane/logs
     env_file:
       - ./apps/api/.env
     depends_on:
       - plane-db
       - plane-redis
+      - plane-mq
 
   live:
     container_name: plane-live
@@ -174,3 +196,7 @@ volumes:
   redisdata:
   uploads:
   rabbitmq_data:
+  logs_api:
+  logs_worker:
+  logs_beat_worker:
+  logs_migrator:


### PR DESCRIPTION
## Summary
- harden the API entrypoint to collect static assets and default worker counts while preserving instance registration
- ensure worker, beat, and migrator entrypoints run as exec-ing processes after waiting for database readiness
- bring the docker-compose stack in line with production defaults by adding log volumes, queue dependencies, and an API healthcheck

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7501841b0832985d7e3e49e1d5da7