### PR TITLE
Ensure frontend base URL env is managed

### DIFF
--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -45,6 +45,7 @@ A dedicated Compose file keeps settings aligned with the published self-host bun
 - Removes bundled Postgres and Redis containers.
 - Injects Neon/Upstash URLs through environment variables (`DATABASE_URL`, `REDIS_URL`, `REDIS_REST_URL`, `REDIS_REST_TOKEN`).
 - Adds health checks so Render/Railway can monitor service status.
+- Sets `NEXT_PUBLIC_API_BASE_URL` dynamically so the frontend calls the API over HTTPS without manual overrides.
 
 You can validate the configuration locally:
 
@@ -63,6 +64,7 @@ Stop the stack with `docker compose ... down` when finished.
    - `REDIS_URL`
    - `REDIS_REST_URL`
    - `REDIS_REST_TOKEN`
+   - `NEXT_PUBLIC_API_BASE_URL` (defaults to `https://<APP_DOMAIN>` when `SSL=true`)
    - Any other secrets listed in `deploy/selfhost/variables.env`
 4. Enable auto-deploy on git push and configure health checks:
    - HTTP health check on `https://<your-domain>/api/health/`

--- a/deploy/cloud/docker-compose.managed.yml
+++ b/deploy/cloud/docker-compose.managed.yml
@@ -63,6 +63,8 @@ services:
   web:
     image: artifacts.plane.so/makeplane/plane-frontend:${APP_RELEASE:-stable}
     command: node web/server.js web
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://localhost}
     deploy:
       replicas: ${WEB_REPLICAS:-1}
       restart_policy:
@@ -76,6 +78,8 @@ services:
   space:
     image: artifacts.plane.so/makeplane/plane-space:${APP_RELEASE:-stable}
     command: node space/server.js space
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://localhost}
     deploy:
       replicas: ${SPACE_REPLICAS:-1}
       restart_policy:
@@ -91,6 +95,8 @@ services:
   admin:
     image: artifacts.plane.so/makeplane/plane-admin:${APP_RELEASE:-stable}
     command: node admin/server.js admin
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://localhost}
     deploy:
       replicas: ${ADMIN_REPLICAS:-1}
       restart_policy:

--- a/deploy/selfhost/README.md
+++ b/deploy/selfhost/README.md
@@ -148,6 +148,8 @@ Below are the most import keys you must refer to. _<span style="color: #fcba03">
 
 > `WEB_URL` - This is default set to `http://localhost`. Change this to the FQDN you plan to use along with NGINX_PORT (eg. `https://plane.example.com:8080` or `http://[IP-ADDRESS]:8080`)
 
+> `NEXT_PUBLIC_API_BASE_URL` - Managed automatically based on `SSL` and `APP_DOMAIN`. Override only when the Plane API is exposed on a separate hostname.
+
 > `CORS_ALLOWED_ORIGINS` - This is default set to `http://localhost`. Change this to the FQDN you plan to use along with NGINX_PORT (eg. `https://plane.example.com:8080` or `http://[IP-ADDRESS]:8080`)
 
 There are many other settings you can play with, but we suggest you configure `EMAIL SETTINGS` as it will enable you to invite your teammates onto the platform.

--- a/deploy/selfhost/docker-compose.yml
+++ b/deploy/selfhost/docker-compose.yml
@@ -62,6 +62,8 @@ services:
   web:
     image: artifacts.plane.so/makeplane/plane-frontend:${APP_RELEASE:-stable}
     command: node web/server.js web
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://localhost}
     deploy:
       replicas: ${WEB_REPLICAS:-1}
       restart_policy:
@@ -73,6 +75,8 @@ services:
   space:
     image: artifacts.plane.so/makeplane/plane-space:${APP_RELEASE:-stable}
     command: node space/server.js space
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://localhost}
     deploy:
       replicas: ${SPACE_REPLICAS:-1}
       restart_policy:
@@ -85,6 +89,8 @@ services:
   admin:
     image: artifacts.plane.so/makeplane/plane-admin:${APP_RELEASE:-stable}
     command: node admin/server.js admin
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://localhost}
     deploy:
       replicas: ${ADMIN_REPLICAS:-1}
       restart_policy:

--- a/deploy/selfhost/install.sh
+++ b/deploy/selfhost/install.sh
@@ -150,6 +150,52 @@ function updateEnvFile() {
     fi
 }
 
+function normalizeBoolean() {
+    local value=$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')
+    case "$value" in
+        1|true|yes|on) echo "true" ;;
+        *) echo "false" ;;
+    esac
+}
+
+function ensureFrontendBaseUrl() {
+    local file=$1
+    local ssl=$(getEnvValue "SSL" "$file")
+    local app_domain=$(getEnvValue "APP_DOMAIN" "$file")
+    local current=$(getEnvValue "NEXT_PUBLIC_API_BASE_URL" "$file")
+
+    if [ -z "$app_domain" ]; then
+        app_domain="localhost"
+    fi
+
+    local protocol="http"
+    if [ "$(normalizeBoolean "$ssl")" == "true" ]; then
+        protocol="https"
+    fi
+
+    local computed_base="${protocol}://${app_domain}"
+    local sanitized_computed="${computed_base%/}"
+    local http_default="http://${app_domain}"
+    local https_default="https://${app_domain}"
+    local sanitized_http="${http_default%/}"
+    local sanitized_https="${https_default%/}"
+    local sanitized_current="${current%/}"
+    local should_update="false"
+
+    if [ -z "$current" ]; then
+        should_update="true"
+    elif [ "$sanitized_current" != "$sanitized_computed" ]; then
+        if [ "$sanitized_current" == "$sanitized_http" ] || [ "$sanitized_current" == "$sanitized_https" ]; then
+            should_update="true"
+        fi
+    fi
+
+    if [ "$should_update" == "true" ]; then
+        updateEnvFile "NEXT_PUBLIC_API_BASE_URL" "$computed_base" "$file"
+        echo "    Updated NEXT_PUBLIC_API_BASE_URL -> $computed_base" >&2
+    fi
+}
+
 function updateCustomVariables(){
     echo "Updating custom variables..." >&2
     updateEnvFile "DOCKERHUB_USER" "$DOCKERHUB_USER" "$DOCKER_ENV_PATH"
@@ -178,6 +224,7 @@ function syncEnvFile(){
             fi
         done < "$DOCKER_ENV_PATH"
     fi
+    ensureFrontendBaseUrl "$DOCKER_ENV_PATH"
     echo "Environment variables synced successfully" >&2
 }
 

--- a/deploy/selfhost/swarm.sh
+++ b/deploy/selfhost/swarm.sh
@@ -72,7 +72,7 @@ function getStackName() {
 
 function syncEnvFile(){
     echo "Syncing environment variables..." >&2
-    if [ -f "$PLANE_INSTALL_DIR/plane.env.bak" ]; then        
+    if [ -f "$PLANE_INSTALL_DIR/plane.env.bak" ]; then
         # READ keys of plane.env and update the values from plane.env.bak
         while IFS= read -r line
         do
@@ -92,6 +92,7 @@ function syncEnvFile(){
             updateEnvFile "STACK_NAME" "$value" "$DOCKER_ENV_PATH"
         fi
     fi
+    ensureFrontendBaseUrl "$DOCKER_ENV_PATH"
     echo "Environment variables synced successfully" >&2
     rm -f $PLANE_INSTALL_DIR/plane.env.bak
 }
@@ -144,6 +145,52 @@ function updateEnvFile() {
     else
         echo "File not found: $file"
         exit 1
+    fi
+}
+
+function normalizeBoolean() {
+    local value=$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')
+    case "$value" in
+        1|true|yes|on) echo "true" ;;
+        *) echo "false" ;;
+    esac
+}
+
+function ensureFrontendBaseUrl() {
+    local file=$1
+    local ssl=$(getEnvValue "SSL" "$file")
+    local app_domain=$(getEnvValue "APP_DOMAIN" "$file")
+    local current=$(getEnvValue "NEXT_PUBLIC_API_BASE_URL" "$file")
+
+    if [ -z "$app_domain" ]; then
+        app_domain="localhost"
+    fi
+
+    local protocol="http"
+    if [ "$(normalizeBoolean "$ssl")" == "true" ]; then
+        protocol="https"
+    fi
+
+    local computed_base="${protocol}://${app_domain}"
+    local sanitized_computed="${computed_base%/}"
+    local http_default="http://${app_domain}"
+    local https_default="https://${app_domain}"
+    local sanitized_http="${http_default%/}"
+    local sanitized_https="${https_default%/}"
+    local sanitized_current="${current%/}"
+    local should_update="false"
+
+    if [ -z "$current" ]; then
+        should_update="true"
+    elif [ "$sanitized_current" != "$sanitized_computed" ]; then
+        if [ "$sanitized_current" == "$sanitized_http" ] || [ "$sanitized_current" == "$sanitized_https" ]; then
+            should_update="true"
+        fi
+    fi
+
+    if [ "$should_update" == "true" ]; then
+        updateEnvFile "NEXT_PUBLIC_API_BASE_URL" "$computed_base" "$file"
+        echo "    Updated NEXT_PUBLIC_API_BASE_URL -> $computed_base" >&2
     fi
 }
 

--- a/deploy/selfhost/variables.env
+++ b/deploy/selfhost/variables.env
@@ -13,6 +13,8 @@ LIVE_REPLICAS=1
 LISTEN_PORT=80
 LISTEN_SSL_PORT=443
 WEB_URL=http://${APP_DOMAIN}
+# Automatically synchronized by setup scripts based on SSL and APP_DOMAIN
+NEXT_PUBLIC_API_BASE_URL=http://${APP_DOMAIN}
 DEBUG=0
 CORS_ALLOWED_ORIGINS=http://${APP_DOMAIN}
 API_BASE_URL=http://api:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: ./apps/web/Dockerfile.web
       args:
         DOCKER_BUILDKIT: 1
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://localhost}
     restart: always
     depends_on:
       - api
@@ -17,6 +19,8 @@ services:
       dockerfile: ./apps/admin/Dockerfile.admin
       args:
         DOCKER_BUILDKIT: 1
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://localhost}
     restart: always
     depends_on:
       - api
@@ -29,6 +33,8 @@ services:
       dockerfile: ./apps/space/Dockerfile.space
       args:
         DOCKER_BUILDKIT: 1
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://localhost}
     restart: always
     depends_on:
       - api


### PR DESCRIPTION
## Summary
- export `NEXT_PUBLIC_API_BASE_URL` for all frontend services across Compose targets
- auto-synchronize the public API base URL during self-host setup based on `SSL` and `APP_DOMAIN`
- document the new behaviour for both self-hosted and managed cloud deployment guides

## Testing
- bash -n deploy/selfhost/install.sh
- bash -n deploy/selfhost/swarm.sh

------
https://chatgpt.com/codex/tasks/task_e_68d7500eb78483298e752c79295c4fc4