### PR TITLE
Add monitoring and metrics endpoint to live collaborative service

### DIFF
--- a/apps/live/src/core/extensions/index.ts
+++ b/apps/live/src/core/extensions/index.ts
@@ -7,6 +7,7 @@ import { Logger } from "@hocuspocus/extension-logger";
 import { Redis as HocusPocusRedis } from "@hocuspocus/extension-redis";
 // core helpers and utilities
 import { manualLogger } from "@/core/helpers/logger.js";
+import { monitoringService } from "@/core/services/monitoring-service.js";
 import { getRedisUrl } from "@/core/lib/utils/redis-url.js";
 // core libraries
 import { fetchPageDescriptionBinary, updatePageDescription } from "@/core/lib/page.js";
@@ -48,6 +49,7 @@ export const getExtensions: () => Promise<Extension[]> = async () => {
             resolve(fetchedData);
           } catch (error) {
             manualLogger.error("Error in fetching document", error);
+            monitoringService.recordIncident("database:fetch", error);
           }
         });
       },
@@ -74,6 +76,7 @@ export const getExtensions: () => Promise<Extension[]> = async () => {
             }
           } catch (error) {
             manualLogger.error("Error in updating document:", error);
+            monitoringService.recordIncident("database:store", error);
           }
         });
       },
@@ -84,6 +87,7 @@ export const getExtensions: () => Promise<Extension[]> = async () => {
 
   if (redisUrl) {
     try {
+      monitoringService.markRedisConnecting();
       const redisClient = new Redis(redisUrl);
 
       await new Promise<void>((resolve, reject) => {
@@ -95,12 +99,14 @@ export const getExtensions: () => Promise<Extension[]> = async () => {
             `Redis Client wasn't able to connect, continuing without Redis (you won't be able to sync data between multiple plane live servers)`,
             error
           );
+          monitoringService.markRedisError(error);
           reject(error);
         });
 
         redisClient.on("ready", () => {
           extensions.push(new HocusPocusRedis({ redis: redisClient }));
           manualLogger.info("Redis Client connected ✅");
+          monitoringService.markRedisConnected();
           resolve();
         });
       });
@@ -109,11 +115,13 @@ export const getExtensions: () => Promise<Extension[]> = async () => {
         `Redis Client wasn't able to connect, continuing without Redis (you won't be able to sync data between multiple plane live servers)`,
         error
       );
+      monitoringService.markRedisError(error);
     }
   } else {
     manualLogger.warn(
       "Redis URL is not set, continuing without Redis (you won't be able to sync data between multiple plane live servers)"
     );
+    monitoringService.markRedisDisabled();
   }
 
   return extensions;

--- a/apps/live/src/core/hocuspocus-server.ts
+++ b/apps/live/src/core/hocuspocus-server.ts
@@ -9,12 +9,24 @@ import { DocumentCollaborativeEvents, TDocumentEventsServer } from "@plane/edito
 import { TUserDetails } from "@plane/editor";
 // types
 import { type HocusPocusServerContext } from "@/core/types/common.js";
+import { monitoringService } from "@/core/services/monitoring-service.js";
 
 export const getHocusPocusServer = async () => {
   const extensions = await getExtensions();
   const serverName = process.env.HOSTNAME || uuidv4();
+  monitoringService.setServerName(serverName);
   return Server.configure({
     name: serverName,
+    async onConnect({ documentName, connection }) {
+      monitoringService.recordCollaborativeConnection({
+        documentName,
+        requiresAuthentication: connection.requiresAuthentication,
+        isAuthenticated: connection.isAuthenticated,
+      });
+    },
+    async onDisconnect({ documentName }) {
+      monitoringService.recordCollaborativeDisconnection(documentName);
+    },
     onAuthenticate: async ({
       requestHeaders,
       context,
@@ -56,12 +68,22 @@ export const getHocusPocusServer = async () => {
         throw Error("Authentication unsuccessful!");
       }
     },
-    async onStateless({ payload, document }) {
+    async onStateless({ payload, document, documentName }) {
       // broadcast the client event (derived from the server event) to all the clients so that they can update their state
+      monitoringService.recordStatelessEvent(documentName);
       const response = DocumentCollaborativeEvents[payload as TDocumentEventsServer].client;
       if (response) {
         document.broadcastStateless(response);
       }
+    },
+    async onChange({ documentName }) {
+      monitoringService.recordDocumentChange(documentName);
+    },
+    async onAwarenessUpdate({ documentName }) {
+      monitoringService.recordAwarenessUpdate(documentName);
+    },
+    async onDestroy() {
+      monitoringService.resetCollaborativeState();
     },
     extensions,
     debounce: 10000,

--- a/apps/live/src/core/services/monitoring-service.ts
+++ b/apps/live/src/core/services/monitoring-service.ts
@@ -1,0 +1,280 @@
+import os from "node:os";
+
+type RedisConnectionStatus = "disabled" | "connecting" | "connected" | "error";
+
+interface ICollaborativeConnectionEvent {
+  documentName?: string;
+  requiresAuthentication?: boolean;
+  isAuthenticated?: boolean;
+}
+
+interface IHttpRequestEvent {
+  method: string;
+  path: string;
+  statusCode: number;
+  durationMs: number;
+}
+
+interface IIncidentRecord {
+  scope: string;
+  message: string;
+  stack?: string;
+  timestamp: string;
+}
+
+export interface IMonitoringSnapshot {
+  startedAt: string;
+  uptimeMs: number;
+  hostname: string;
+  serverName?: string;
+  port?: number;
+  lastActivityAt?: string;
+  http: {
+    totalRequests: number;
+    successfulRequests: number;
+    failedRequests: number;
+    averageDurationMs: number;
+    lastRequestAt?: string;
+    lastRoute?: string;
+    lastStatusCode?: number;
+  };
+  collaboration: {
+    totalConnections: number;
+    activeConnections: number;
+    documentConnections: Record<string, number>;
+    totalDocumentChanges: number;
+    totalAwarenessUpdates: number;
+    totalStatelessEvents: number;
+    lastEventAt?: string;
+  };
+  redis: {
+    status: RedisConnectionStatus;
+    configured: boolean;
+    lastChangedAt: string;
+    lastError?: string;
+  };
+  incidents: IIncidentRecord[];
+}
+
+type RedisState = {
+  status: RedisConnectionStatus;
+  configured: boolean;
+  lastChangedAt: string;
+  lastError?: string;
+};
+
+class MonitoringService {
+  private readonly startedAt: number;
+  private port?: number;
+  private serverName?: string;
+  private lastActivityAt?: string;
+
+  private totalConnections = 0;
+  private activeConnections = 0;
+  private documentConnections: Map<string, number> = new Map();
+  private totalDocumentChanges = 0;
+  private totalAwarenessUpdates = 0;
+  private totalStatelessEvents = 0;
+  private lastEventAt?: string;
+
+  private totalRequests = 0;
+  private successfulRequests = 0;
+  private failedRequests = 0;
+  private totalRequestDurationMs = 0;
+  private lastRequestAt?: string;
+  private lastRoute?: string;
+  private lastStatusCode?: number;
+
+  private readonly incidents: IIncidentRecord[] = [];
+  private readonly maxIncidentRecords = 50;
+
+  private redisState: RedisState = {
+    status: "disabled",
+    configured: false,
+    lastChangedAt: new Date().toISOString(),
+    lastError: undefined,
+  };
+
+  constructor() {
+    this.startedAt = Date.now();
+  }
+
+  public setServerName(name: string) {
+    this.serverName = name;
+  }
+
+  public setPort(port: number | string) {
+    const parsedPort = typeof port === "string" ? Number.parseInt(port, 10) : port;
+    if (!Number.isNaN(parsedPort)) {
+      this.port = parsedPort;
+    }
+  }
+
+  public recordCollaborativeConnection(event: ICollaborativeConnectionEvent) {
+    this.totalConnections += 1;
+    this.activeConnections = Math.max(0, this.activeConnections + 1);
+    const documentName = event.documentName ?? "unknown";
+    const current = this.documentConnections.get(documentName) ?? 0;
+    this.documentConnections.set(documentName, current + 1);
+    this.touchActivity();
+  }
+
+  public recordCollaborativeDisconnection(documentName?: string) {
+    this.activeConnections = Math.max(0, this.activeConnections - 1);
+    if (documentName) {
+      const current = this.documentConnections.get(documentName) ?? 0;
+      if (current <= 1) {
+        this.documentConnections.delete(documentName);
+      } else {
+        this.documentConnections.set(documentName, current - 1);
+      }
+    }
+    this.touchActivity();
+  }
+
+  public recordDocumentChange(documentName?: string) {
+    this.totalDocumentChanges += 1;
+    this.registerDocumentActivity(documentName);
+  }
+
+  public recordAwarenessUpdate(documentName?: string) {
+    this.totalAwarenessUpdates += 1;
+    this.registerDocumentActivity(documentName);
+  }
+
+  public recordStatelessEvent(documentName?: string) {
+    this.totalStatelessEvents += 1;
+    this.registerDocumentActivity(documentName);
+  }
+
+  public trackHttpRequest(event: IHttpRequestEvent) {
+    this.totalRequests += 1;
+    const isSuccessful = event.statusCode >= 200 && event.statusCode < 400;
+    if (isSuccessful) {
+      this.successfulRequests += 1;
+    } else {
+      this.failedRequests += 1;
+    }
+    this.totalRequestDurationMs += event.durationMs;
+    this.lastRequestAt = new Date().toISOString();
+    this.lastRoute = `${event.method.toUpperCase()} ${event.path}`;
+    this.lastStatusCode = event.statusCode;
+    this.touchActivity();
+  }
+
+  public recordIncident(scope: string, error: unknown) {
+    const timestamp = new Date().toISOString();
+    const message = error instanceof Error ? error.message : String(error);
+    const stack = error instanceof Error ? error.stack : undefined;
+    this.incidents.unshift({ scope, message, stack, timestamp });
+    if (this.incidents.length > this.maxIncidentRecords) {
+      this.incidents.length = this.maxIncidentRecords;
+    }
+    this.touchActivity();
+  }
+
+  public resetCollaborativeState() {
+    this.activeConnections = 0;
+    this.documentConnections.clear();
+    this.totalDocumentChanges = 0;
+    this.totalAwarenessUpdates = 0;
+    this.totalStatelessEvents = 0;
+    this.lastEventAt = new Date().toISOString();
+    this.touchActivity();
+  }
+
+  public markRedisDisabled() {
+    this.redisState = {
+      status: "disabled",
+      configured: false,
+      lastChangedAt: new Date().toISOString(),
+      lastError: undefined,
+    };
+  }
+
+  public markRedisConnecting() {
+    this.redisState = {
+      status: "connecting",
+      configured: true,
+      lastChangedAt: new Date().toISOString(),
+      lastError: undefined,
+    };
+  }
+
+  public markRedisConnected() {
+    this.redisState = {
+      status: "connected",
+      configured: true,
+      lastChangedAt: new Date().toISOString(),
+      lastError: undefined,
+    };
+  }
+
+  public markRedisError(error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    this.redisState = {
+      status: "error",
+      configured: true,
+      lastChangedAt: new Date().toISOString(),
+      lastError: message,
+    };
+    this.recordIncident("redis", error);
+  }
+
+  public getSnapshot(): IMonitoringSnapshot {
+    const uptimeMs = Date.now() - this.startedAt;
+    const documentConnections = Object.fromEntries(this.documentConnections.entries());
+    const averageDurationMs = this.totalRequests === 0 ? 0 : this.totalRequestDurationMs / this.totalRequests;
+
+    return {
+      startedAt: new Date(this.startedAt).toISOString(),
+      uptimeMs,
+      hostname: os.hostname(),
+      serverName: this.serverName,
+      port: this.port,
+      lastActivityAt: this.lastActivityAt,
+      http: {
+        totalRequests: this.totalRequests,
+        successfulRequests: this.successfulRequests,
+        failedRequests: this.failedRequests,
+        averageDurationMs,
+        lastRequestAt: this.lastRequestAt,
+        lastRoute: this.lastRoute,
+        lastStatusCode: this.lastStatusCode,
+      },
+      collaboration: {
+        totalConnections: this.totalConnections,
+        activeConnections: this.activeConnections,
+        documentConnections,
+        totalDocumentChanges: this.totalDocumentChanges,
+        totalAwarenessUpdates: this.totalAwarenessUpdates,
+        totalStatelessEvents: this.totalStatelessEvents,
+        lastEventAt: this.lastEventAt,
+      },
+      redis: {
+        status: this.redisState.status,
+        configured: this.redisState.configured,
+        lastChangedAt: this.redisState.lastChangedAt,
+        lastError: this.redisState.lastError,
+      },
+      incidents: [...this.incidents],
+    };
+  }
+
+  private touchActivity() {
+    this.lastActivityAt = new Date().toISOString();
+  }
+
+  private registerDocumentActivity(documentName?: string) {
+    if (documentName) {
+      const current = this.documentConnections.get(documentName) ?? 0;
+      if (current === 0) {
+        this.documentConnections.set(documentName, 0);
+      }
+    }
+    this.lastEventAt = new Date().toISOString();
+    this.touchActivity();
+  }
+}
+
+export const monitoringService = new MonitoringService();

--- a/apps/live/src/server.ts
+++ b/apps/live/src/server.ts
@@ -1,13 +1,14 @@
 import compression from "compression";
 import cors from "cors";
 import expressWs from "express-ws";
-import express, { Request, Response } from "express";
+import express, { NextFunction, Request, Response } from "express";
 import helmet from "helmet";
 // hocuspocus server
 import { getHocusPocusServer } from "@/core/hocuspocus-server.js";
 // helpers
 import { convertHTMLDocumentToAllFormats } from "@/core/helpers/convert-document.js";
 import { logger, manualLogger } from "@/core/helpers/logger.js";
+import { monitoringService } from "@/core/services/monitoring-service.js";
 // types
 import { TConvertDocumentRequestBody } from "@/core/types/common.js";
 
@@ -32,6 +33,24 @@ export class Server {
     this.app.use(helmet());
     // Middleware for response compression
     this.app.use(compression({ level: 6, threshold: 5 * 1000 }));
+    // Monitoring middleware for request lifecycle
+    this.app.use((req: Request, res: Response, next: NextFunction) => {
+      const start = process.hrtime();
+      res.on("finish", () => {
+        const diff = process.hrtime(start);
+        const durationMs = diff[0] * 1000 + diff[1] / 1e6;
+        monitoringService.trackHttpRequest({
+          method: req.method,
+          path: req.originalUrl || req.url,
+          statusCode: res.statusCode,
+          durationMs,
+        });
+      });
+      res.on("error", (error) => {
+        monitoringService.recordIncident("http:response", error);
+      });
+      next();
+    });
     // Logging middleware
     this.app.use(logger);
     // Body parsing middleware
@@ -45,6 +64,7 @@ export class Server {
   private async setupHocusPocus() {
     this.hocuspocusServer = await getHocusPocusServer().catch((err) => {
       manualLogger.error("Failed to initialize HocusPocusServer:", err);
+      monitoringService.recordIncident("hocuspocus:init", err);
       process.exit(1);
     });
   }
@@ -54,11 +74,16 @@ export class Server {
       res.status(200).json({ status: "OK" });
     });
 
+    this.router.get("/health/metrics", (_req: Request, res: Response) => {
+      res.status(200).json(monitoringService.getSnapshot());
+    });
+
     this.router.ws("/collaboration", (ws: any, req: Request) => {
       try {
         this.hocuspocusServer.handleConnection(ws, req);
       } catch (err) {
         manualLogger.error("WebSocket connection error:", err);
+        monitoringService.recordIncident("websocket:connection", err);
         ws.close();
       }
     });
@@ -82,6 +107,7 @@ export class Server {
         });
       } catch (error) {
         manualLogger.error("Error in /convert-document endpoint:", error);
+        monitoringService.recordIncident("http:convert-document", error);
         res.status(500).send({
           message: `Internal server error. ${error}`,
         });
@@ -96,6 +122,7 @@ export class Server {
   public listen() {
     this.serverInstance = this.app.listen(this.app.get("port"), () => {
       manualLogger.info(`Plane Live server has started at port ${this.app.get("port")}`);
+      monitoringService.setPort(this.app.get("port"));
     });
   }
 
@@ -103,6 +130,7 @@ export class Server {
     // Close the HocusPocus server WebSocket connections
     await this.hocuspocusServer.destroy();
     manualLogger.info("HocusPocus server WebSocket connections closed gracefully.");
+    monitoringService.resetCollaborativeState();
     // Close the Express server
     this.serverInstance.close(() => {
       manualLogger.info("Express server closed gracefully.");
@@ -118,6 +146,7 @@ server.listen();
 process.on("unhandledRejection", async (err: any) => {
   manualLogger.info("Unhandled Rejection: ", err);
   manualLogger.info(`UNHANDLED REJECTION! 💥 Shutting down...`);
+  monitoringService.recordIncident("process:unhandledRejection", err);
   await server.destroy();
 });
 
@@ -125,5 +154,6 @@ process.on("unhandledRejection", async (err: any) => {
 process.on("uncaughtException", async (err: any) => {
   manualLogger.info("Uncaught Exception: ", err);
   manualLogger.info(`UNCAUGHT EXCEPTION! 💥 Shutting down...`);
+  monitoringService.recordIncident("process:uncaughtException", err);
   await server.destroy();
 });


### PR DESCRIPTION
## Summary
- introduce a monitoring service that tracks HTTP activity, collaborative events, Redis state, and incidents for the live server
- instrument the HocusPocus server lifecycle and Redis extension to feed monitoring data and expose it via a new `/health/metrics` endpoint

## Testing
- yarn workspace live check:types *(fails: missing @plane/* module type declarations in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d750238a3c8329882dc03ab5f68add