### PR TITLE
Add performance telemetry to the web app monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ See [CONTRIBUTING](./CONTRIBUTING.md)
 - Verify external dependencies (PostgreSQL, Redis, and RabbitMQ) with `python manage.py monitor_services`. The command exits non-zero when a dependency is unreachable, making it safe for CI and deployment hooks.
 - Automate periodic health checks with [`scripts/monitoring/service_healthcheck.py`](scripts/monitoring/service_healthcheck.py), which wraps the management command and emits structured logs for observability platforms.
 - Follow the [Railway deployment blueprint](docs/deployment/railway.md) when containerizing the Django API with managed backing services—it's aligned with the production Dockerfile and keeps the existing application interface intact.
+- When deploying the Next.js workspace to Netlify, follow the [Netlify deployment guide](docs/deployment/netlify.md) to connect GitHub, target the correct base directory, enforce Node.js 18+, and provision required environment variables without diverging from the current interface.
 
 ## 📝 Documentation
 Explore Plane's [product documentation](https://docs.plane.so/) and [developer documentation](https://developers.plane.so/) to learn about features, setup, and usage.

--- a/apps/web/core/lib/monitoring/app-monitor.ts
+++ b/apps/web/core/lib/monitoring/app-monitor.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { captureError } from "@/helpers/event-tracker.helper";
+import { captureError, captureSuccess } from "@/helpers/event-tracker.helper";
+import { PerformanceMetricsCollector, type PerformanceMetricReporter } from "./performance-metrics";
 
 type ErrorContext = Record<string, unknown>;
 
@@ -90,10 +91,22 @@ const reportThroughAnalytics = (
   });
 };
 
+const reportPerformanceMetric: PerformanceMetricReporter = (metric, payload) => {
+  captureSuccess({
+    eventName: "app_monitor_performance",
+    payload: {
+      metric,
+      ...payload,
+    },
+    context: buildRuntimeContext(),
+  });
+};
+
 export class AppMonitor {
   private started = false;
   private removeListeners: Array<() => void> = [];
   private recentErrors = new Map<string, number>();
+  private performanceCollector = new PerformanceMetricsCollector(reportPerformanceMetric);
 
   start(): void {
     if (this.started) return;
@@ -133,10 +146,14 @@ export class AppMonitor {
     this.removeListeners.push(() =>
       window.removeEventListener("unhandledrejection", handleUnhandledRejection)
     );
+
+    this.performanceCollector.start();
   }
 
   stop(): void {
     if (!this.started) return;
+
+    this.performanceCollector.stop();
 
     while (this.removeListeners.length) {
       const remove = this.removeListeners.pop();

--- a/apps/web/core/lib/monitoring/performance-metrics.ts
+++ b/apps/web/core/lib/monitoring/performance-metrics.ts
@@ -1,0 +1,285 @@
+"use client";
+
+export type PerformanceMetricReporter = (
+  metric: string,
+  payload: Record<string, unknown>
+) => void;
+
+type LargestContentfulPaintEntry = PerformanceEntry & {
+  id?: string;
+  size?: number;
+  url?: string;
+  element?: Element | null;
+  renderTime?: number;
+  loadTime?: number;
+};
+
+type LayoutShiftEntry = PerformanceEntry & {
+  value?: number;
+  hadRecentInput?: boolean;
+};
+
+type FirstInputEntry = PerformanceEntry & {
+  processingStart?: number;
+  cancelable?: boolean;
+  target?: EventTarget | null;
+  interactionId?: number;
+};
+
+type LongTaskAttribution = {
+  name?: string;
+  entryType?: string;
+  startTime?: number;
+  duration?: number;
+  containerType?: string;
+  containerName?: string;
+  containerId?: string;
+  containerSrc?: string;
+};
+
+type LongTaskEntry = PerformanceEntry & {
+  attribution?: LongTaskAttribution[];
+};
+
+type ResourceErrorTarget =
+  | HTMLImageElement
+  | HTMLScriptElement
+  | HTMLLinkElement
+  | HTMLVideoElement
+  | HTMLSourceElement
+  | SVGImageElement;
+
+const LONG_TASK_THRESHOLD_MS = 50;
+const MAX_HTML_SNAPSHOT_LENGTH = 512;
+
+export class PerformanceMetricsCollector {
+  private observers: PerformanceObserver[] = [];
+  private cleanupCallbacks: Array<() => void> = [];
+  private started = false;
+  private layoutShiftScore = 0;
+  private lastLcpEntry: LargestContentfulPaintEntry | undefined;
+
+  constructor(private readonly report: PerformanceMetricReporter) {}
+
+  start(): void {
+    if (this.started) return;
+    if (typeof window === "undefined" || typeof performance === "undefined") return;
+    this.started = true;
+
+    this.captureNavigationTiming();
+    this.observePaintTimings();
+    this.observeLargestContentfulPaint();
+    this.observeLayoutShift();
+    this.observeLongTasks();
+    this.observeFirstInputDelay();
+    this.observeResourceFailures();
+  }
+
+  stop(): void {
+    if (!this.started) return;
+
+    this.flushLargestContentfulPaint("stop");
+
+    while (this.cleanupCallbacks.length) {
+      const remove = this.cleanupCallbacks.pop();
+      try {
+        remove?.();
+      } catch (error) {
+        // Swallow cleanup errors to avoid interfering with app shutdown
+      }
+    }
+
+    for (const observer of this.observers) {
+      try {
+        observer.disconnect();
+      } catch (error) {
+        // Ignore observer cleanup failures
+      }
+    }
+
+    this.observers = [];
+    this.layoutShiftScore = 0;
+    this.lastLcpEntry = undefined;
+    this.started = false;
+  }
+
+  private addCleanup(callback: () => void): void {
+    this.cleanupCallbacks.push(callback);
+  }
+
+  private tryObserve(type: string, callback: (entry: PerformanceEntry) => void): void {
+    if (typeof PerformanceObserver === "undefined") return;
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          callback(entry);
+        }
+      });
+      observer.observe({ type: type as any, buffered: true });
+      this.observers.push(observer);
+    } catch (error) {
+      // Ignore unsupported entry types in current runtime
+    }
+  }
+
+  private captureNavigationTiming(): void {
+    const navigationEntries = performance.getEntriesByType("navigation") as PerformanceNavigationTiming[];
+    if (!navigationEntries.length) return;
+
+    const [navigation] = navigationEntries;
+    this.report("navigation", {
+      duration: navigation.duration,
+      domInteractive: navigation.domInteractive,
+      domContentLoaded: navigation.domContentLoadedEventEnd,
+      domComplete: navigation.domComplete,
+      responseEnd: navigation.responseEnd,
+      transferSize: navigation.transferSize,
+      encodedBodySize: navigation.encodedBodySize,
+      decodedBodySize: navigation.decodedBodySize,
+      type: navigation.type,
+      redirectCount: navigation.redirectCount,
+    });
+  }
+
+  private observePaintTimings(): void {
+    this.tryObserve("paint", (entry) => {
+      if (entry.name === "first-paint" || entry.name === "first-contentful-paint") {
+        this.report(entry.name, {
+          startTime: entry.startTime,
+          duration: entry.duration,
+        });
+      }
+    });
+  }
+
+  private observeLargestContentfulPaint(): void {
+    if (typeof document === "undefined") return;
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        this.flushLargestContentfulPaint("visibilitychange");
+      }
+    };
+
+    const handlePageHide = () => {
+      this.flushLargestContentfulPaint("pagehide");
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("pagehide", handlePageHide);
+
+    this.addCleanup(() => document.removeEventListener("visibilitychange", handleVisibilityChange));
+    this.addCleanup(() => window.removeEventListener("pagehide", handlePageHide));
+
+    this.tryObserve("largest-contentful-paint", (entry) => {
+      this.lastLcpEntry = entry as LargestContentfulPaintEntry;
+    });
+  }
+
+  private flushLargestContentfulPaint(trigger: string): void {
+    if (!this.lastLcpEntry) return;
+
+    const entry = this.lastLcpEntry;
+    const renderTime = entry.renderTime ?? entry.loadTime ?? entry.startTime;
+    const element = entry.element ?? undefined;
+
+    this.report("largest_contentful_paint", {
+      trigger,
+      value: renderTime,
+      size: entry.size,
+      id: entry.id,
+      url: entry.url,
+      tagName: element instanceof Element ? element.tagName : undefined,
+    });
+
+    this.lastLcpEntry = undefined;
+  }
+
+  private observeLayoutShift(): void {
+    this.tryObserve("layout-shift", (entry) => {
+      const layoutEntry = entry as LayoutShiftEntry;
+      if (layoutEntry.hadRecentInput) return;
+
+      const delta = layoutEntry.value ?? 0;
+      if (delta <= 0) return;
+
+      this.layoutShiftScore += delta;
+      this.report("cumulative_layout_shift", {
+        delta,
+        value: this.layoutShiftScore,
+        startTime: entry.startTime,
+      });
+    });
+  }
+
+  private observeLongTasks(): void {
+    this.tryObserve("longtask", (entry) => {
+      if (entry.duration < LONG_TASK_THRESHOLD_MS) return;
+
+      const longTask = entry as LongTaskEntry;
+      this.report("long_task", {
+        duration: entry.duration,
+        startTime: entry.startTime,
+        name: entry.name,
+        attribution: longTask.attribution?.map((item) => ({
+          name: item.name,
+          entryType: item.entryType,
+          startTime: item.startTime,
+          duration: item.duration,
+          containerType: item.containerType,
+          containerName: item.containerName,
+          containerId: item.containerId,
+          containerSrc: item.containerSrc,
+        })),
+      });
+    });
+  }
+
+  private observeFirstInputDelay(): void {
+    this.tryObserve("first-input", (entry) => {
+      const firstInput = entry as FirstInputEntry;
+      const processingStart = firstInput.processingStart ?? 0;
+      const delay = processingStart > 0 ? processingStart - entry.startTime : 0;
+
+      this.report("first_input_delay", {
+        name: entry.name,
+        delay,
+        duration: entry.duration,
+        startTime: entry.startTime,
+        cancelable: firstInput.cancelable,
+        interactionId: firstInput.interactionId,
+      });
+    });
+  }
+
+  private observeResourceFailures(): void {
+    const handleResourceError = (event: Event) => {
+      if (event instanceof ErrorEvent) return;
+
+      const target = event.target as ResourceErrorTarget | null;
+      if (!target || !(target instanceof Element)) return;
+
+      let url: string | undefined;
+      if (target instanceof HTMLImageElement || target instanceof HTMLVideoElement) {
+        url = target.currentSrc || target.src || undefined;
+      } else if (target instanceof HTMLSourceElement) {
+        url = target.src;
+      } else if (target instanceof HTMLScriptElement) {
+        url = target.src;
+      } else if (target instanceof HTMLLinkElement) {
+        url = target.href;
+      } else if (typeof SVGImageElement !== "undefined" && target instanceof SVGImageElement) {
+        url = target.href?.baseVal;
+      }
+
+      this.report("resource_error", {
+        tagName: target.tagName,
+        url,
+        outerHTML: typeof target.outerHTML === "string" ? target.outerHTML.slice(0, MAX_HTML_SNAPSHOT_LENGTH) : undefined,
+      });
+    };
+
+    window.addEventListener("error", handleResourceError, true);
+    this.addCleanup(() => window.removeEventListener("error", handleResourceError, true));
+  }
+}

--- a/docs/deployment/netlify.md
+++ b/docs/deployment/netlify.md
@@ -1,0 +1,57 @@
+# Netlify Deployment Guide
+
+This guide explains how to connect the Plane repository to Netlify, configure the build to use the Next.js web application, and supply the runtime environment variables Netlify needs in production. Follow the checklist before enabling automatic deployments so that the connection is stable and reproducible.
+
+## 1. Connect the GitHub repository
+
+1. Sign in to Netlify and choose **Add new site → Import an existing project**.
+2. Select **GitHub** as the Git provider and authorize Netlify if this is the first time.
+3. Pick the Plane repository (`plane-software/plane` or the fork you maintain) from the repository list.
+4. Leave the deploy configuration screen open for the next steps; do not trigger the first build yet.
+
+> ℹ️ **Tip:** If Netlify cannot locate the repository, verify that the GitHub account you authorized has at least `Read` access and that third-party application restrictions are disabled for the organization.
+
+## 2. Set the base directory to the Next.js app
+
+The Plane monorepo hosts multiple applications. Netlify must build the Next.js web client located at `apps/web`.
+
+1. In the **Basic build settings**, set the **Base directory** field to `apps/web`.
+2. Netlify automatically prefixes subsequent paths with this base, so the default **Build command** `yarn build` and **Publish directory** `.next` work without additional changes.
+3. Ensure the repository contains a lockfile (`yarn.lock`) so that Netlify respects the workspace dependency graph during installation.
+
+## 3. Pin the Node.js runtime to v18+
+
+Plane’s web application targets Node.js 18. Set the version explicitly so that future Netlify upgrades do not break the build.
+
+1. Scroll to the **Environment variables** section.
+2. Add a variable named `NODE_VERSION` with the value `18` (or a more recent LTS release such as `18.19.1`).
+3. Alternatively, add an `.nvmrc` file at the repository root containing `18`, but keeping the Netlify variable ensures the runtime stays in sync with the CI matrix.
+
+## 4. Supply required environment variables
+
+Plane reads configuration at build time and runtime. At minimum provide the following variables in Netlify:
+
+| Variable | Purpose |
+| --- | --- |
+| `NEXT_PUBLIC_API_BASE_URL` | Points the web client to the Plane API instance. |
+| `NEXT_PUBLIC_POSTHOG_KEY` | Enables product analytics and monitoring. |
+| `NEXT_PUBLIC_POSTHOG_HOST` | Override if you self-host PostHog. |
+| `NEXT_PUBLIC_INTERCOM_APP_ID` | Required when Intercom is enabled. |
+| `NEXT_PUBLIC_SENTRY_DSN` | Optional but recommended for additional error observability. |
+| `PLANE_CLOUD` | Set to `true` when deploying the managed Plane Cloud experience. |
+
+> 📌 **Recommendation:** Store secrets in Netlify’s **Shared environment variables** UI so all deploy contexts (production, preview, branch) inherit the same configuration. Override per-context values only when absolutely necessary.
+
+## 5. Trigger the initial build
+
+1. Click **Save** after entering the environment variables.
+2. Start the first deploy. Netlify installs dependencies from the root `package.json`, runs `yarn build` inside `apps/web`, and publishes the `.next` output directory.
+3. Verify the deployment log includes `Next.js`, `Turbo`, and `PostHog` initialization to confirm the monitoring hooks (including the App Monitor) are active.
+
+## 6. Monitor deployments
+
+* Enable Netlify’s **Deploy notifications** so the team is alerted to regressions.
+* Pair Netlify deploys with the `scripts/monitoring/service_healthcheck.py` helper from this repository to validate backend dependencies before promoting a build.
+* The enhanced client-side monitoring added to the App Monitor automatically records performance metrics (navigation timing, Largest Contentful Paint, and more) in PostHog, helping you correlate Netlify releases with end-user impact.
+
+By following this procedure, you ensure Netlify builds the correct workspace with the expected runtime, reducing merge conflicts and configuration drift between environments.


### PR DESCRIPTION
## Summary
- extend the web AppMonitor to emit PostHog performance metrics without changing its public interface
- add a dedicated performance metrics collector that observes navigation, paint, LCP, layout shifts, long tasks, input delay, and resource failures
- document the Netlify deployment workflow (GitHub connection, base directory, Node 18+, and environment variables) and link it from the README

## Testing
- yarn workspace web check:types *(fails: workspace aliases such as `@plane/constants` are unresolved when running `tsc --noEmit` outside the Turbo graph)*

------
https://chatgpt.com/codex/tasks/task_e_68d756212d68832995b8513ff1c00b2f