### PR TITLE
Add runtime monitoring integrations and AGPL footer notice

### DIFF
--- a/apps/web/core/components/global/index.ts
+++ b/apps/web/core/components/global/index.ts
@@ -1,3 +1,4 @@
 export * from "./product-updates";
 
 export * from "./timezone-select";
+export * from "./legal";

--- a/apps/web/core/components/global/legal/index.ts
+++ b/apps/web/core/components/global/legal/index.ts
@@ -1,0 +1,1 @@
+export * from "./legal-footer";

--- a/apps/web/core/components/global/legal/legal-footer.tsx
+++ b/apps/web/core/components/global/legal/legal-footer.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+import { FC } from "react";
+
+import { cn } from "@plane/utils";
+
+type LegalFooterProps = {
+  className?: string;
+};
+
+const AGPL_LICENSE_URL = "https://www.gnu.org/licenses/agpl-3.0.en.html";
+const SOURCE_CODE_URL = "https://github.com/makeplane/plane";
+
+export const LegalFooter: FC<LegalFooterProps> = ({ className }) => (
+  <footer
+    className={cn(
+      "flex w-full flex-wrap items-center justify-center gap-x-3 gap-y-2 border-t border-custom-border-200/60 bg-custom-background-100/90 px-6 py-3 text-xs text-custom-text-300 backdrop-blur",
+      className
+    )}
+    role="contentinfo"
+  >
+    <span className="text-center">
+      Released under the{" "}
+      <Link
+        href={AGPL_LICENSE_URL}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="font-medium text-custom-text-200 underline decoration-custom-text-200/60 underline-offset-2 transition-colors hover:text-custom-text-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-custom-primary-100 focus-visible:ring-offset-2 focus-visible:ring-offset-custom-background-100"
+      >
+        GNU Affero General Public License v3.0
+      </Link>
+      .
+    </span>
+    <span className="text-center">
+      <Link
+        href={SOURCE_CODE_URL}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="font-medium text-custom-text-200 underline decoration-custom-text-200/60 underline-offset-2 transition-colors hover:text-custom-text-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-custom-primary-100 focus-visible:ring-offset-2 focus-visible:ring-offset-custom-background-100"
+      >
+        Source
+      </Link>
+    </span>
+  </footer>
+);
+
+export default LegalFooter;

--- a/apps/web/core/layouts/default-layout/index.tsx
+++ b/apps/web/core/layouts/default-layout/index.tsx
@@ -1,6 +1,8 @@
 import { FC, ReactNode } from "react";
 import { cn } from "@plane/utils";
 
+import { LegalFooter } from "@/components/global";
+
 type Props = {
   children: ReactNode;
   gradient?: boolean;
@@ -8,8 +10,14 @@ type Props = {
 };
 
 const DefaultLayout: FC<Props> = ({ children, gradient = false, className }) => (
-  <div className={cn(`h-screen w-full overflow-hidden ${gradient ? "" : "bg-custom-background-100"}`, className)}>
-    {children}
+  <div
+    className={cn(
+      `flex h-screen w-full flex-col overflow-hidden ${gradient ? "" : "bg-custom-background-100"}`,
+      className
+    )}
+  >
+    <div className="flex-1">{children}</div>
+    <LegalFooter className="mt-auto" />
   </div>
 );
 

--- a/apps/web/core/lib/monitoring/app-monitor.ts
+++ b/apps/web/core/lib/monitoring/app-monitor.ts
@@ -14,6 +14,7 @@ type NormalizedError = {
 type EventSource = "error" | "unhandledrejection" | "manual";
 
 const DEDUPLICATION_WINDOW = 10_000; // 10 seconds
+const LONG_TASK_THRESHOLD = 200; // milliseconds
 
 const stringifyUnknown = (value: unknown): string => {
   if (typeof value === "string") return value;
@@ -94,6 +95,7 @@ export class AppMonitor {
   private started = false;
   private removeListeners: Array<() => void> = [];
   private recentErrors = new Map<string, number>();
+  private restoreConsole?: () => void;
 
   start(): void {
     if (this.started) return;
@@ -133,6 +135,9 @@ export class AppMonitor {
     this.removeListeners.push(() =>
       window.removeEventListener("unhandledrejection", handleUnhandledRejection)
     );
+
+    this.installConsoleInterceptors();
+    this.installLongTaskObserver();
   }
 
   stop(): void {
@@ -142,7 +147,7 @@ export class AppMonitor {
       const remove = this.removeListeners.pop();
       try {
         remove?.();
-      } catch (error) {
+      } catch {
         // Swallow removal errors silently
       }
     }
@@ -174,6 +179,95 @@ export class AppMonitor {
 
     this.recentErrors.set(key, now);
     return true;
+  }
+
+  private installConsoleInterceptors(): void {
+    if (this.restoreConsole) return;
+
+    const globalConsole = console;
+    const originalError = globalConsole.error.bind(globalConsole);
+    const originalWarn = globalConsole.warn.bind(globalConsole);
+
+    const intercept = (level: "error" | "warn", original: (...args: unknown[]) => void) =>
+      (...args: unknown[]) => {
+        try {
+          original(...args);
+        } finally {
+          const serialized = args.map(stringifyUnknown).join(" ");
+          if (!serialized) return;
+
+          const label = level === "error" ? "Console error" : "Console warning";
+          this.captureException(new Error(`${label}: ${serialized}`), {
+            channel: "console",
+            level,
+          });
+        }
+      };
+
+    globalConsole.error = intercept("error", originalError);
+    globalConsole.warn = intercept("warn", originalWarn);
+
+    this.restoreConsole = () => {
+      globalConsole.error = originalError;
+      globalConsole.warn = originalWarn;
+      this.restoreConsole = undefined;
+    };
+
+    this.removeListeners.push(() => {
+      try {
+        this.restoreConsole?.();
+      } catch {
+        // Ignore restoration issues
+      }
+    });
+  }
+
+  private installLongTaskObserver(): void {
+    if (typeof window === "undefined") return;
+    if (typeof PerformanceObserver === "undefined") return;
+
+    let observer: PerformanceObserver | undefined;
+
+    try {
+      observer = new PerformanceObserver((entryList) => {
+        for (const entry of entryList.getEntries()) {
+          if (entry.entryType !== "longtask") continue;
+          const duration = entry.duration;
+          if (duration < LONG_TASK_THRESHOLD) continue;
+
+          this.captureException(`Long task detected (${Math.round(duration)}ms)`, {
+            channel: "performance",
+            entryType: entry.entryType,
+            name: entry.name,
+            duration,
+            startTime: entry.startTime,
+            threshold: LONG_TASK_THRESHOLD,
+          });
+        }
+      });
+
+      observer.observe({ entryTypes: ["longtask"] });
+    } catch (error) {
+      this.captureException(error, {
+        channel: "performance_observer",
+        entryType: "longtask",
+        action: "observe",
+      });
+      observer?.disconnect();
+      return;
+    }
+
+    this.removeListeners.push(() => {
+      try {
+        observer?.disconnect();
+      } catch (error) {
+        this.captureException(error, {
+          channel: "performance_observer",
+          entryType: "longtask",
+          action: "disconnect",
+        });
+      }
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- extend the client-side app monitor with console interception and long-task tracking to improve runtime diagnostics
- add a reusable legal footer component that surfaces the AGPL notice and a Source link
- render the legal footer from the default layout so non-authenticated screens consistently show the notice

## Testing
- yarn workspace web check:lint *(fails: existing lint violations across the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d7562324308329a31fba270d1c833e