### PR TITLE
feat(web): add api rewrites and monitoring

### DIFF
--- a/apps/web/config/url-utils.js
+++ b/apps/web/config/url-utils.js
@@ -1,0 +1,26 @@
+const normalizeBaseUrl = (url) => {
+  if (!url || typeof url !== "string") return "";
+  return url.trim().replace(/\/+$/, "");
+};
+
+const normalizeBasePath = (path) => {
+  if (!path || typeof path !== "string") return "";
+  const trimmed = path.trim();
+  if (!trimmed) return "";
+  const withoutSlashes = trimmed.replace(/^\/+/, "").replace(/\/+$/, "");
+  if (!withoutSlashes) return "";
+  return `/${withoutSlashes}`;
+};
+
+const buildExternalRewrite = (baseUrl, basePath = "") => {
+  const normalizedUrl = normalizeBaseUrl(baseUrl);
+  if (!normalizedUrl) return "";
+  const normalizedPath = normalizeBasePath(basePath);
+  return `${normalizedUrl}${normalizedPath}`;
+};
+
+module.exports = {
+  normalizeBaseUrl,
+  normalizeBasePath,
+  buildExternalRewrite,
+};

--- a/apps/web/core/lib/monitoring/app-monitor.ts
+++ b/apps/web/core/lib/monitoring/app-monitor.ts
@@ -1,54 +1,13 @@
 "use client";
 
 import { captureError } from "@/helpers/event-tracker.helper";
+import { type NormalizedError, normalizeError } from "@/lib/monitoring/error-normalizer";
 
 type ErrorContext = Record<string, unknown>;
-
-type NormalizedError = {
-  name?: string;
-  message: string;
-  stack?: string;
-  cause?: unknown;
-};
 
 type EventSource = "error" | "unhandledrejection" | "manual";
 
 const DEDUPLICATION_WINDOW = 10_000; // 10 seconds
-
-const stringifyUnknown = (value: unknown): string => {
-  if (typeof value === "string") return value;
-  if (value instanceof Error) return value.message;
-  try {
-    return JSON.stringify(value);
-  } catch (error) {
-    return String(value);
-  }
-};
-
-const normalizeError = (error: unknown): NormalizedError => {
-  if (error instanceof Error) {
-    const normalized: NormalizedError = {
-      name: error.name,
-      message: error.message,
-      stack: error.stack ?? undefined,
-    };
-    if ((error as { cause?: unknown }).cause) {
-      normalized.cause = stringifyUnknown((error as { cause?: unknown }).cause);
-    }
-    return normalized;
-  }
-
-  if (typeof error === "string") {
-    return { message: error };
-  }
-
-  if (typeof error === "object" && error !== null) {
-    const serialized = stringifyUnknown(error);
-    return { message: serialized };
-  }
-
-  return { message: String(error) };
-};
 
 const resolveKey = (error: NormalizedError): string => {
   const stackFragment = error.stack ? error.stack.split("\n")[0] : "";

--- a/apps/web/core/lib/monitoring/error-normalizer.ts
+++ b/apps/web/core/lib/monitoring/error-normalizer.ts
@@ -1,0 +1,51 @@
+export type NormalizedError = {
+  name?: string;
+  message: string;
+  stack?: string;
+  cause?: unknown;
+};
+
+export const stringifyUnknown = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return value.message;
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    return String(value);
+  }
+};
+
+export const normalizeError = (error: unknown): NormalizedError => {
+  if (error instanceof Error) {
+    const normalized: NormalizedError = {
+      name: error.name,
+      message: error.message,
+      stack: error.stack ?? undefined,
+    };
+    if ((error as { cause?: unknown }).cause) {
+      normalized.cause = stringifyUnknown((error as { cause?: unknown }).cause);
+    }
+    return normalized;
+  }
+
+  if (typeof error === "string") {
+    return { message: error };
+  }
+
+  if (typeof error === "object" && error !== null) {
+    const serialized = stringifyUnknown(error);
+    return { message: serialized };
+  }
+
+  return { message: String(error) };
+};
+
+export const describeNormalizedError = (error: NormalizedError): string => {
+  const segments = [
+    error.name ? `[${error.name}]` : undefined,
+    error.message,
+    error.stack ? `stack=${error.stack}` : undefined,
+    error.cause ? `cause=${error.cause}` : undefined,
+  ].filter(Boolean);
+  return segments.join(" ");
+};

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,79 @@
+import { logger } from "@plane/logger";
+
+import {
+  describeNormalizedError,
+  normalizeError,
+  stringifyUnknown,
+} from "@/lib/monitoring/error-normalizer";
+
+const REGISTERED_KEY = Symbol.for("plane.web.monitoring.registered");
+
+type GlobalWithMonitoring = typeof globalThis & {
+  [REGISTERED_KEY]?: boolean;
+};
+
+const globalScope = globalThis as GlobalWithMonitoring;
+
+const markAsRegistered = () => {
+  Object.defineProperty(globalScope, REGISTERED_KEY, {
+    value: true,
+    configurable: false,
+    enumerable: false,
+    writable: false,
+  });
+};
+
+const isRegistered = () => Boolean(globalScope[REGISTERED_KEY]);
+
+const formatMessage = (title: string, details: string[]) =>
+  [title, ...details.filter(Boolean)].join(" ");
+
+export async function register(): Promise<void> {
+  if (isRegistered()) {
+    return;
+  }
+
+  markAsRegistered();
+
+  const handleUnhandledRejection = (reason: unknown) => {
+    const normalized = normalizeError(reason);
+    logger.error(
+      formatMessage("Unhandled promise rejection detected.", [
+        describeNormalizedError(normalized),
+      ])
+    );
+  };
+
+  const handleUncaughtException = (error: Error) => {
+    const normalized = normalizeError(error);
+    logger.error(
+      formatMessage("Uncaught exception detected.", [
+        describeNormalizedError(normalized),
+      ])
+    );
+  };
+
+  const handleWarning = (warning: Error) => {
+    const normalized = normalizeError(warning);
+    logger.warn(
+      formatMessage("Process warning emitted.", [describeNormalizedError(normalized)])
+    );
+  };
+
+  const handleRejectionHandled = (promise: Promise<unknown>) => {
+    if (typeof logger.debug === "function") {
+      logger.debug(
+        formatMessage("Promise rejection handled after being reported.", [
+          `promise=${stringifyUnknown(promise)}`,
+        ])
+      );
+    }
+  };
+
+  process.on("unhandledRejection", handleUnhandledRejection);
+  process.on("uncaughtException", handleUncaughtException);
+  process.on("warning", handleWarning);
+  process.on("rejectionHandled", handleRejectionHandled);
+
+  logger.info("Server monitoring hooks registered for Plane Web.");
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -3,6 +3,8 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 require("dotenv").config({ path: ".env" });
 
+const { buildExternalRewrite } = require("./config/url-utils");
+
 const nextConfig = {
   trailingSlash: true,
   reactStrictMode: false,
@@ -105,6 +107,22 @@ const nextConfig = {
         destination: `${posthogHost}/:path*`,
       },
     ];
+
+    const apiDestinationBase = buildExternalRewrite(
+      process.env.NEXT_PUBLIC_API_BASE_URL,
+      process.env.NEXT_PUBLIC_API_BASE_PATH
+    );
+
+    if (apiDestinationBase) {
+      rewrites.push({
+        source: "/api/:path*",
+        destination: `${apiDestinationBase}/:path*`,
+      });
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn("Skipping /api rewrite because NEXT_PUBLIC_API_BASE_URL is not defined.");
+    }
+
     if (process.env.NEXT_PUBLIC_ADMIN_BASE_URL || process.env.NEXT_PUBLIC_ADMIN_BASE_PATH) {
       const ADMIN_BASE_URL = process.env.NEXT_PUBLIC_ADMIN_BASE_URL || "";
       const ADMIN_BASE_PATH = process.env.NEXT_PUBLIC_ADMIN_BASE_PATH || "";


### PR DESCRIPTION
## Summary
- add shared error normalizer utilities and server instrumentation to improve monitoring coverage
- extend Next.js rewrites with a reusable URL helper and /api proxy support

## Testing
- yarn workspace web lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7562eabcc8329849ce47467fbcd3f