### PR TITLE
Add monitoring telemetry and revalidation plumbing for Space

### DIFF
--- a/apps/space/app/api/monitoring/log/route.ts
+++ b/apps/space/app/api/monitoring/log/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { logger } from "@plane/logger";
+
+export const runtime = "nodejs";
+
+interface MonitoringPayload {
+  timestamp?: string;
+  source?: string;
+  error?: {
+    name?: string;
+    message: string;
+    stack?: string;
+    cause?: unknown;
+  };
+  context?: Record<string, unknown>;
+}
+
+const sanitizePayload = (payload: MonitoringPayload) => {
+  const { error, context, source, timestamp } = payload;
+  return {
+    timestamp: timestamp || new Date().toISOString(),
+    source: source || "unknown",
+    error: {
+      name: error?.name,
+      message: error?.message || "Unknown client error",
+      stack: error?.stack,
+      cause: error?.cause,
+    },
+    context: context || {},
+  };
+};
+
+export async function POST(request: Request) {
+  try {
+    const payload = (await request.json()) as MonitoringPayload;
+    const sanitized = sanitizePayload(payload);
+
+    logger.error(
+      `[client-monitoring] source=${sanitized.source} message="${sanitized.error.message}" context=${JSON.stringify(
+        sanitized.context
+      )}`
+    );
+
+    return NextResponse.json({ received: true });
+  } catch (error) {
+    logger.error(`[client-monitoring] Failed to record client error: ${error instanceof Error ? error.message : String(error)}`);
+    return NextResponse.json({ error: "Invalid monitoring payload" }, { status: 400 });
+  }
+}

--- a/apps/space/app/api/revalidate/route.ts
+++ b/apps/space/app/api/revalidate/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from "next/server";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { logger } from "@plane/logger";
+
+import { isCacheTagValue } from "@/lib/cache/tags";
+
+export const runtime = "nodejs";
+
+const resolveSecret = () => process.env.REVALIDATION_SECRET || process.env.REVALIDATE_SECRET;
+
+type RevalidatePayload = {
+  secret?: string;
+  tag?: string;
+  tags?: string[];
+  path?: string;
+  paths?: string[];
+};
+
+const normalizeTags = (payload: RevalidatePayload): string[] => {
+  const candidateTags = [payload.tag, ...(payload.tags ?? [])].filter(Boolean) as string[];
+  const unique = new Set<string>();
+
+  for (const tag of candidateTags) {
+    if (isCacheTagValue(tag)) {
+      unique.add(tag);
+    }
+  }
+
+  return Array.from(unique);
+};
+
+const normalizePaths = (payload: RevalidatePayload): string[] => {
+  const candidatePaths = [payload.path, ...(payload.paths ?? [])].filter(Boolean) as string[];
+  const unique = new Set<string>();
+
+  for (const path of candidatePaths) {
+    if (typeof path === "string" && path.startsWith("/")) {
+      unique.add(path);
+    }
+  }
+
+  return Array.from(unique);
+};
+
+export async function POST(request: Request) {
+  let payload: RevalidatePayload;
+
+  try {
+    payload = (await request.json()) as RevalidatePayload;
+  } catch (error) {
+    logger.warn(`[revalidate] Invalid JSON payload: ${error instanceof Error ? error.message : String(error)}`);
+    return NextResponse.json({ error: "Invalid request payload" }, { status: 400 });
+  }
+
+  const secret = resolveSecret();
+  if (!secret) {
+    logger.error("[revalidate] Revalidation secret is not configured.");
+    return NextResponse.json({ error: "Revalidation secret not configured" }, { status: 500 });
+  }
+
+  if (!payload?.secret || payload.secret !== secret) {
+    return NextResponse.json({ error: "Invalid revalidation secret" }, { status: 401 });
+  }
+
+  const tags = normalizeTags(payload);
+  const paths = normalizePaths(payload);
+
+  if (!tags.length && !paths.length) {
+    return NextResponse.json({ error: "No valid tags or paths provided" }, { status: 400 });
+  }
+
+  const revalidated = { tags: [] as string[], paths: [] as string[] };
+
+  for (const tag of tags) {
+    try {
+      await revalidateTag(tag);
+      revalidated.tags.push(tag);
+    } catch (error) {
+      logger.error(`[revalidate] Failed to revalidate tag "${tag}": ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  for (const path of paths) {
+    try {
+      await revalidatePath(path);
+      revalidated.paths.push(path);
+    } catch (error) {
+      logger.error(
+        `[revalidate] Failed to revalidate path "${path}": ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  logger.info(
+    `[revalidate] Completed revalidation request. Tags: [${revalidated.tags.join(", ")}] Paths: [${revalidated.paths.join(", ")}]`
+  );
+
+  return NextResponse.json({
+    revalidated,
+    receivedAt: new Date().toISOString(),
+  });
+}

--- a/apps/space/app/issues/[anchor]/client-layout.tsx
+++ b/apps/space/app/issues/[anchor]/client-layout.tsx
@@ -8,6 +8,8 @@ import { IssuesNavbarRoot } from "@/components/issues";
 import { SomethingWentWrongError } from "@/components/issues/issue-layouts/error";
 // hooks
 import { useIssueFilter, usePublish, usePublishList } from "@/hooks/store";
+// monitoring
+import { appMonitor } from "@/lib/monitoring";
 
 type Props = {
   children: React.ReactNode;
@@ -36,7 +38,14 @@ export const IssuesClientLayout = observer((props: Props) => {
             });
           }
         }
-      : null
+      : null,
+    {
+      onError: (fetchError) =>
+        appMonitor.captureException(fetchError, {
+          feature: "public-issues-layout",
+          anchor,
+        }),
+    }
   );
 
   if (!publishSettings && !error) return <LogoSpinner />;

--- a/apps/space/app/issues/[anchor]/layout.tsx
+++ b/apps/space/app/issues/[anchor]/layout.tsx
@@ -1,5 +1,9 @@
 "use server";
 
+import { logger } from "@plane/logger";
+
+import { fetchAnchorMetadata } from "@/lib/server/fetch-anchor-metadata";
+
 import { IssuesClientLayout } from "./client-layout";
 
 type Props = {
@@ -14,32 +18,44 @@ export async function generateMetadata({ params }: Props) {
   const DEFAULT_TITLE = "Plane";
   const DEFAULT_DESCRIPTION = "Made with Plane, an AI-powered work management platform with publishing capabilities.";
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/public/anchor/${anchor}/meta/`);
-    const data = await response.json();
-    return {
-      title: data?.name || DEFAULT_TITLE,
-      description: data?.description || DEFAULT_DESCRIPTION,
-      openGraph: {
-        title: data?.name || DEFAULT_TITLE,
-        description: data?.description || DEFAULT_DESCRIPTION,
-        type: "website",
-        images: [
+    const data = await fetchAnchorMetadata(anchor);
+    const title = data?.name || DEFAULT_TITLE;
+    const description = data?.description || DEFAULT_DESCRIPTION;
+    const coverImage = data?.cover_image;
+
+    const openGraphImages = coverImage
+      ? [
           {
-            url: data?.cover_image,
+            url: coverImage,
             width: 800,
             height: 600,
-            alt: data?.name || DEFAULT_TITLE,
+            alt: title,
           },
-        ],
+        ]
+      : [];
+
+    const twitterImages = coverImage ? [coverImage] : undefined;
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        type: "website",
+        images: openGraphImages,
       },
       twitter: {
         card: "summary_large_image",
-        title: data?.name || DEFAULT_TITLE,
-        description: data?.description || DEFAULT_DESCRIPTION,
-        images: [data?.cover_image],
+        title,
+        description,
+        images: twitterImages,
       },
     };
-  } catch {
+  } catch (error) {
+    logger.error(
+      `[metadata] Falling back to defaults for anchor "${anchor}": ${error instanceof Error ? error.message : String(error)}`
+    );
     return { title: DEFAULT_TITLE, description: DEFAULT_DESCRIPTION };
   }
 }

--- a/apps/space/app/provider.tsx
+++ b/apps/space/app/provider.tsx
@@ -4,6 +4,7 @@ import { FC, ReactNode } from "react";
 // components
 import { TranslationProvider } from "@plane/i18n";
 import { InstanceProvider } from "@/lib/instance-provider";
+import { MonitoringProvider } from "@/lib/monitoring";
 import { StoreProvider } from "@/lib/store-provider";
 import { ToastProvider } from "@/lib/toast-provider";
 
@@ -18,7 +19,9 @@ export const AppProvider: FC<IAppProvider> = (props) => {
     <StoreProvider>
       <TranslationProvider>
         <ToastProvider>
-          <InstanceProvider>{children}</InstanceProvider>
+          <MonitoringProvider>
+            <InstanceProvider>{children}</InstanceProvider>
+          </MonitoringProvider>
         </ToastProvider>
       </TranslationProvider>
     </StoreProvider>

--- a/apps/space/app/views/[anchor]/layout.tsx
+++ b/apps/space/app/views/[anchor]/layout.tsx
@@ -10,6 +10,8 @@ import { usePublish, usePublishList } from "@/hooks/store";
 // Plane web
 import { ViewNavbarRoot } from "@/plane-web/components/navbar";
 import { useView } from "@/plane-web/hooks/store";
+// monitoring
+import { appMonitor } from "@/lib/monitoring";
 
 type Props = {
   children: React.ReactNode;
@@ -37,7 +39,14 @@ const IssuesLayout = observer((props: Props) => {
           promises.push(fetchViewDetails(anchor));
           await Promise.all(promises);
         }
-      : null
+      : null,
+    {
+      onError: (fetchError) =>
+        appMonitor.captureException(fetchError, {
+          feature: "public-view-layout",
+          anchor,
+        }),
+    }
   );
 
   if (error) return <SomethingWentWrongError />;

--- a/apps/space/core/lib/cache/tags.ts
+++ b/apps/space/core/lib/cache/tags.ts
@@ -1,0 +1,14 @@
+export const CacheTag = {
+  anchorMetadata: (anchor: string) => `anchor:metadata:${anchor}`,
+  anchorSettings: (anchor: string) => `anchor:settings:${anchor}`,
+  anchorView: (anchor: string) => `anchor:view:${anchor}`,
+} as const;
+
+type CacheTagGenerators = typeof CacheTag;
+
+export type CacheTagValue = ReturnType<CacheTagGenerators[keyof CacheTagGenerators]>;
+
+export const isCacheTagValue = (value: unknown): value is CacheTagValue => {
+  if (typeof value !== "string") return false;
+  return value.startsWith("anchor:");
+};

--- a/apps/space/core/lib/monitoring/app-monitor.ts
+++ b/apps/space/core/lib/monitoring/app-monitor.ts
@@ -1,0 +1,191 @@
+"use client";
+
+type ErrorContext = Record<string, unknown>;
+
+type NormalizedError = {
+  name?: string;
+  message: string;
+  stack?: string;
+  cause?: unknown;
+};
+
+type EventSource = "error" | "unhandledrejection" | "manual";
+
+const DEDUPLICATION_WINDOW = 10_000; // 10 seconds
+
+const stringifyUnknown = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return value.message;
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    return String(value);
+  }
+};
+
+const normalizeError = (error: unknown): NormalizedError => {
+  if (error instanceof Error) {
+    const normalized: NormalizedError = {
+      name: error.name,
+      message: error.message,
+      stack: error.stack ?? undefined,
+    };
+    if ((error as { cause?: unknown }).cause) {
+      normalized.cause = stringifyUnknown((error as { cause?: unknown }).cause);
+    }
+    return normalized;
+  }
+
+  if (typeof error === "string") {
+    return { message: error };
+  }
+
+  if (typeof error === "object" && error !== null) {
+    const serialized = stringifyUnknown(error);
+    return { message: serialized };
+  }
+
+  return { message: String(error) };
+};
+
+const resolveKey = (error: NormalizedError): string => {
+  const stackFragment = error.stack ? error.stack.split("\n")[0] : "";
+  return [error.name ?? "Error", error.message, stackFragment].filter(Boolean).join(":");
+};
+
+const buildRuntimeContext = (): ErrorContext => {
+  if (typeof window === "undefined") return {};
+
+  const { location, navigator } = window;
+  return {
+    url: location?.href,
+    pathname: location?.pathname,
+    search: location?.search,
+    hash: location?.hash,
+    userAgent: navigator?.userAgent,
+    language: navigator?.language,
+    platform: navigator?.platform,
+    online: navigator?.onLine,
+  };
+};
+
+const sendErrorReport = (source: EventSource, normalizedError: NormalizedError, context?: ErrorContext) => {
+  if (typeof window === "undefined") return;
+
+  const payload = {
+    timestamp: new Date().toISOString(),
+    source,
+    error: normalizedError,
+    context: {
+      ...buildRuntimeContext(),
+      ...context,
+    },
+  };
+
+  try {
+    const body = JSON.stringify(payload);
+    if (navigator?.sendBeacon) {
+      const blob = new Blob([body], { type: "application/json" });
+      navigator.sendBeacon("/api/monitoring/log", blob);
+      return;
+    }
+
+    void fetch("/api/monitoring/log", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+      keepalive: true,
+    });
+  } catch (error) {
+    console.error("[app-monitor] Failed to report error", error);
+  }
+};
+
+export class AppMonitor {
+  private started = false;
+  private removeListeners: Array<() => void> = [];
+  private recentErrors = new Map<string, number>();
+
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleError = (event: ErrorEvent) => {
+      const normalized = normalizeError(event.error || event.message || "Unknown runtime error");
+      if (!this.shouldReport(normalized)) return;
+
+      sendErrorReport("error", normalized, {
+        filename: event.filename,
+        lineno: event.lineno,
+        colno: event.colno,
+        type: event.type,
+        isTrusted: event.isTrusted,
+      });
+    };
+
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      const normalized = normalizeError(event.reason || "Unhandled rejection");
+      if (!this.shouldReport(normalized)) return;
+
+      sendErrorReport("unhandledrejection", normalized, {
+        type: event.type,
+        isTrusted: event.isTrusted,
+      });
+    };
+
+    window.addEventListener("error", handleError);
+    this.removeListeners.push(() => window.removeEventListener("error", handleError));
+
+    window.addEventListener("unhandledrejection", handleUnhandledRejection);
+    this.removeListeners.push(() =>
+      window.removeEventListener("unhandledrejection", handleUnhandledRejection)
+    );
+  }
+
+  stop(): void {
+    if (!this.started) return;
+
+    while (this.removeListeners.length) {
+      const remove = this.removeListeners.pop();
+      try {
+        remove?.();
+      } catch (error) {
+        console.error("[app-monitor] Failed to remove listener", error);
+      }
+    }
+
+    this.started = false;
+  }
+
+  captureException(error: unknown, context?: ErrorContext): void {
+    const normalized = normalizeError(error);
+    if (!this.shouldReport(normalized)) return;
+
+    sendErrorReport("manual", normalized, context);
+  }
+
+  private shouldReport(error: NormalizedError): boolean {
+    const key = resolveKey(error);
+    const now = Date.now();
+    const lastTimestamp = this.recentErrors.get(key) ?? 0;
+
+    for (const [storedKey, timestamp] of this.recentErrors.entries()) {
+      if (now - timestamp > DEDUPLICATION_WINDOW) {
+        this.recentErrors.delete(storedKey);
+      }
+    }
+
+    if (now - lastTimestamp < DEDUPLICATION_WINDOW) {
+      return false;
+    }
+
+    this.recentErrors.set(key, now);
+    return true;
+  }
+}
+
+export const appMonitor = new AppMonitor();

--- a/apps/space/core/lib/monitoring/index.ts
+++ b/apps/space/core/lib/monitoring/index.ts
@@ -1,0 +1,2 @@
+export { MonitoringProvider } from "./monitoring-provider";
+export { appMonitor, AppMonitor } from "./app-monitor";

--- a/apps/space/core/lib/monitoring/monitoring-provider.tsx
+++ b/apps/space/core/lib/monitoring/monitoring-provider.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { FC, PropsWithChildren, useEffect } from "react";
+
+import { appMonitor } from "./app-monitor";
+
+type MonitoringProviderProps = PropsWithChildren<Record<string, never>>;
+
+export const MonitoringProvider: FC<MonitoringProviderProps> = ({ children }) => {
+  useEffect(() => {
+    appMonitor.start();
+    return () => {
+      appMonitor.stop();
+    };
+  }, []);
+
+  return <>{children}</>;
+};
+
+export default MonitoringProvider;

--- a/apps/space/core/lib/server/fetch-anchor-metadata.ts
+++ b/apps/space/core/lib/server/fetch-anchor-metadata.ts
@@ -1,0 +1,51 @@
+import "server-only";
+
+import { logger } from "@plane/logger";
+
+import { CacheTag } from "@/lib/cache/tags";
+
+const DEFAULT_REVALIDATE_SECONDS = Number(process.env.SPACE_ANCHOR_METADATA_REVALIDATE ?? 300);
+
+export type AnchorMetadata = {
+  name?: string;
+  description?: string;
+  cover_image?: string;
+};
+
+const sanitizeBaseUrl = (url: string) => url.replace(/\/$/, "");
+
+export const fetchAnchorMetadata = async (anchor: string): Promise<AnchorMetadata | null> => {
+  if (!anchor) {
+    throw new Error("Anchor must be provided to fetch metadata.");
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  if (!baseUrl) {
+    throw new Error("NEXT_PUBLIC_API_BASE_URL is not configured.");
+  }
+
+  const url = `${sanitizeBaseUrl(baseUrl)}/api/public/anchor/${anchor}/meta/`;
+
+  try {
+    const response = await fetch(url, {
+      // Force ISR caching with explicit revalidation and tagging for selective invalidation.
+      next: {
+        revalidate: Number.isFinite(DEFAULT_REVALIDATE_SECONDS) ? DEFAULT_REVALIDATE_SECONDS : 300,
+        tags: [CacheTag.anchorMetadata(anchor)],
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch metadata. Status: ${response.status}`);
+    }
+
+    const payload = (await response.json()) as AnchorMetadata | null;
+    return payload;
+  } catch (error) {
+    logger.error(
+      `[anchor-metadata] Unable to fetch metadata for anchor "${anchor}": ${error instanceof Error ? error.message : String(error)}`
+    );
+    throw error;
+  }
+};


### PR DESCRIPTION
## Summary
- add cache tag helpers and a server-side metadata fetcher that opts anchor metadata into ISR with cache tags
- introduce on-demand revalidation and client monitoring log API routes backed by the shared logger
- wrap the app provider with a monitoring layer and capture SWR failures for public layouts

## Testing
- yarn --cwd apps/space check:types *(fails: TypeScript cannot resolve several @plane/* workspace packages in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d75648de4083298cc405d0e42dc1c6