### PR TITLE
Add Netlify logging pipeline and backend telemetry instrumentation

### DIFF
--- a/apps/api/plane/asgi.py
+++ b/apps/api/plane/asgi.py
@@ -1,14 +1,24 @@
+import logging
 import os
 
 from channels.routing import ProtocolTypeRouter
 from django.core.asgi import get_asgi_application
 
-django_asgi_app = get_asgi_application()
-
+from plane.utils.telemetry import init_tracer
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "plane.settings.production")
+
+try:
+    init_tracer()
+except Exception as exc:  # pragma: no cover - defensive logging
+    logging.getLogger("plane.observability").warning(
+        "Failed to initialize backend APM for ASGI startup.",
+        extra={"error": str(exc), "channel": "observability", "event": "apm_startup_failed"},
+    )
+
+django_asgi_app = get_asgi_application()
+
 # Initialize Django ASGI application early to ensure the AppRegistry
 # is populated before importing code that may import ORM models.
-
 
 application = ProtocolTypeRouter({"http": get_asgi_application()})

--- a/apps/api/plane/celery.py
+++ b/apps/api/plane/celery.py
@@ -10,6 +10,7 @@ from celery.schedules import crontab
 
 # Module imports
 from plane.settings.redis import redis_instance
+from plane.utils.telemetry import init_tracer
 
 # Set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "plane.settings.production")
@@ -21,6 +22,14 @@ app = Celery("plane")
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
 app.config_from_object("django.conf:settings", namespace="CELERY")
+
+try:
+    init_tracer()
+except Exception as exc:  # pragma: no cover - defensive logging
+    logging.getLogger("plane.observability").warning(
+        "Failed to initialize backend APM for Celery worker.",
+        extra={"error": str(exc), "channel": "observability", "event": "apm_startup_failed"},
+    )
 
 app.conf.beat_schedule = {
     # Intra day recurring jobs

--- a/apps/api/plane/utils/telemetry.py
+++ b/apps/api/plane/utils/telemetry.py
@@ -1,58 +1,143 @@
+"""Utilities to configure application observability and tracing."""
+
 # Python imports
-import os
 import atexit
+import logging
+import os
+from typing import Dict, Optional
 
 # Third party imports
 from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.django import DjangoInstrumentor
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.instrumentation.django import DjangoInstrumentor
 
-# Global variable to track initialization
-_TRACER_PROVIDER = None
+logger = logging.getLogger("plane.observability")
+
+_TRACER_PROVIDER: Optional[TracerProvider] = None
+_DJANGO_INSTRUMENTED = False
 
 
-def init_tracer():
-    """Initialize OpenTelemetry with proper shutdown handling"""
+def _is_truthy(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _is_apm_enabled() -> bool:
+    explicit = os.environ.get("ENABLE_BACKEND_APM") or os.environ.get(
+        "ENABLE_OTEL_TRACES"
+    )
+    if explicit is not None:
+        return _is_truthy(explicit)
+    if os.environ.get("OTLP_ENDPOINT"):
+        return True
+    return False
+
+
+def _resolve_otlp_headers() -> Optional[Dict[str, str]]:
+    headers = os.environ.get("OTLP_HEADERS")
+    if not headers:
+        return None
+    parsed: Dict[str, str] = {}
+    for pair in headers.split(","):
+        if not pair:
+            continue
+        if "=" not in pair:
+            continue
+        key, value = pair.split("=", 1)
+        parsed[key.strip()] = value.strip()
+    return parsed or None
+
+
+def init_tracer() -> Optional[TracerProvider]:
+    """Initialize OpenTelemetry with proper shutdown handling."""
+
     global _TRACER_PROVIDER
+    global _DJANGO_INSTRUMENTED
 
-    # If already initialized, return existing provider
+    if not _is_apm_enabled():
+        logger.debug("Backend APM instrumentation disabled by configuration.")
+        return None
+
     if _TRACER_PROVIDER is not None:
         return _TRACER_PROVIDER
 
-    # Configure the tracer provider
     service_name = os.environ.get("SERVICE_NAME", "plane-ce-api")
     resource = Resource.create({"service.name": service_name})
     tracer_provider = TracerProvider(resource=resource)
 
-    # Set as global tracer provider
     trace.set_tracer_provider(tracer_provider)
 
-    # Configure the OTLP exporter
-    otel_endpoint = os.environ.get("OTLP_ENDPOINT", "https://telemetry.plane.so")
-    otlp_exporter = OTLPSpanExporter(endpoint=otel_endpoint)
-    span_processor = BatchSpanProcessor(otlp_exporter)
+    endpoint = os.environ.get("OTLP_ENDPOINT", "https://telemetry.plane.so")
+    headers = _resolve_otlp_headers()
+    insecure = _is_truthy(os.environ.get("OTLP_INSECURE"))
+
+    try:
+        exporter = OTLPSpanExporter(endpoint=endpoint, headers=headers, insecure=insecure)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning(
+            "Failed to configure OTLP exporter; backend APM will remain disabled.",
+            extra={
+                "channel": "observability",
+                "event": "apm_init_failed",
+                "error": str(exc),
+            },
+        )
+        return None
+
+    span_processor = BatchSpanProcessor(exporter)
     tracer_provider.add_span_processor(span_processor)
 
-    # Initialize Django instrumentation
-    DjangoInstrumentor().instrument()
+    if not _DJANGO_INSTRUMENTED:
+        try:
+            DjangoInstrumentor().instrument()
+            _DJANGO_INSTRUMENTED = True
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning(
+                "Failed to instrument Django for OpenTelemetry.",
+                extra={
+                    "channel": "observability",
+                    "event": "django_instrumentation_failed",
+                    "error": str(exc),
+                },
+            )
 
-    # Store provider globally
     _TRACER_PROVIDER = tracer_provider
 
-    # Register shutdown handler
     atexit.register(shutdown_tracer)
+
+    logger.info(
+        "Backend APM instrumentation enabled.",
+        extra={
+            "channel": "observability",
+            "event": "apm_initialized",
+            "endpoint": endpoint,
+            "service": service_name,
+        },
+    )
 
     return tracer_provider
 
 
-def shutdown_tracer():
-    """Shutdown OpenTelemetry tracers and processors"""
+def shutdown_tracer() -> None:
+    """Shutdown OpenTelemetry tracers and processors."""
+
     global _TRACER_PROVIDER
 
     if _TRACER_PROVIDER is not None:
         if hasattr(_TRACER_PROVIDER, "shutdown"):
-            _TRACER_PROVIDER.shutdown()
+            try:
+                _TRACER_PROVIDER.shutdown()
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.warning(
+                    "Error encountered while shutting down tracer provider.",
+                    extra={
+                        "channel": "observability",
+                        "event": "apm_shutdown_failed",
+                        "error": str(exc),
+                    },
+                )
         _TRACER_PROVIDER = None

--- a/apps/api/plane/wsgi.py
+++ b/apps/api/plane/wsgi.py
@@ -1,14 +1,20 @@
-"""
-WSGI config for plane project.
+"""WSGI config for Plane project with observability hooks."""
 
-It exposes the WSGI callable as a module-level variable named ``application``.
-
-"""
-
+import logging
 import os
 
 from django.core.wsgi import get_wsgi_application
 
+from plane.utils.telemetry import init_tracer
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "plane.settings.production")
+
+try:
+    init_tracer()
+except Exception as exc:  # pragma: no cover - defensive logging
+    logging.getLogger("plane.observability").warning(
+        "Failed to initialize backend APM for WSGI startup.",
+        extra={"error": str(exc), "channel": "observability", "event": "apm_startup_failed"},
+    )
 
 application = get_wsgi_application()

--- a/apps/web/app/api/monitoring/log/route.ts
+++ b/apps/web/app/api/monitoring/log/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { logger } from "@plane/logger";
+
+type LogLevel = "debug" | "info" | "warn" | "error";
+type EventKind = "error" | "metric" | "lifecycle";
+
+type ObservabilityPayload = {
+  kind?: EventKind;
+  name?: string;
+  level?: LogLevel;
+  message?: string;
+  metric?: string;
+  source?: string;
+  runtime?: string;
+  timestamp?: string;
+  context?: Record<string, unknown>;
+  payload?: Record<string, unknown>;
+  error?: Record<string, unknown>;
+  truncated?: boolean;
+};
+
+const MAX_BODY_LENGTH = 60_000;
+const MAX_STRING_LENGTH = 4096;
+const MAX_ARRAY_ITEMS = 25;
+const MAX_OBJECT_KEYS = 40;
+
+const truthy = (value: string | undefined | null | boolean): boolean => {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return false;
+  switch (value.toLowerCase()) {
+    case "1":
+    case "true":
+    case "yes":
+    case "on":
+      return true;
+    default:
+      return false;
+  }
+};
+
+const isLoggingEnabled = (): boolean => {
+  const explicit = process.env.ENABLE_NETLIFY_LOGS ?? process.env.PLANE_NETLIFY_LOGS;
+  if (truthy(explicit)) return true;
+  if (truthy(process.env.NETLIFY)) return true;
+  return false;
+};
+
+const sanitizeString = (value: unknown, limit = MAX_STRING_LENGTH): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  if (value.length <= limit) return value;
+  return `${value.slice(0, limit)}…`;
+};
+
+const sanitizeUnknown = (value: unknown, depth = 0): unknown => {
+  if (depth > 3) return "[max-depth-exceeded]";
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") return sanitizeString(value) ?? "";
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) {
+    return value.slice(0, MAX_ARRAY_ITEMS).map((item) => sanitizeUnknown(item, depth + 1));
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).slice(0, MAX_OBJECT_KEYS);
+    const result: Record<string, unknown> = {};
+    for (const [key, raw] of entries) {
+      result[key] = sanitizeUnknown(raw, depth + 1);
+    }
+    return result;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return String(value);
+  }
+};
+
+const sanitizeRecord = (value: unknown): Record<string, unknown> | undefined => {
+  if (!value || typeof value !== "object") return undefined;
+  return sanitizeUnknown(value) as Record<string, unknown>;
+};
+
+const parseLevel = (input: unknown, kind: EventKind | undefined): LogLevel => {
+  const normalized = typeof input === "string" ? input.toLowerCase() : undefined;
+  if (normalized === "debug" || normalized === "info" || normalized === "warn" || normalized === "error") {
+    return normalized;
+  }
+  if (kind === "error") return "error";
+  return "info";
+};
+
+const parseKind = (value: unknown): EventKind | undefined => {
+  if (value === "error" || value === "metric" || value === "lifecycle") return value;
+  return undefined;
+};
+
+const readPayload = async (request: NextRequest): Promise<ObservabilityPayload | undefined> => {
+  const raw = await request.text();
+  if (!raw) return undefined;
+
+  const trimmed = raw.length > MAX_BODY_LENGTH ? raw.slice(0, MAX_BODY_LENGTH) : raw;
+
+  try {
+    return JSON.parse(trimmed) as ObservabilityPayload;
+  } catch (error) {
+    logger.warn("Failed to parse observability payload", {
+      channel: "observability",
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+};
+
+const buildLogContext = (
+  request: NextRequest,
+  payload: ObservabilityPayload
+): Record<string, unknown> => {
+  const headers = request.headers;
+  return {
+    event_kind: payload.kind,
+    event_name: payload.name,
+    event_metric: payload.metric,
+    runtime: payload.runtime,
+    timestamp: payload.timestamp,
+    context: sanitizeRecord(payload.context),
+    payload: sanitizeRecord(payload.payload),
+    error: sanitizeRecord(payload.error),
+    truncated: payload.truncated,
+    request_id:
+      headers.get("x-nf-request-id") ??
+      headers.get("x-amzn-trace-id") ??
+      headers.get("x-request-id"),
+    user_agent: headers.get("user-agent"),
+    forwarded_for: headers.get("x-forwarded-for"),
+    source: payload.source,
+  };
+};
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const body = await readPayload(request);
+
+  if (!body) {
+    return new Response(null, { status: 204 });
+  }
+
+  if (!isLoggingEnabled()) {
+    return new Response(null, { status: 204 });
+  }
+
+  const kind = parseKind(body.kind);
+  const level = parseLevel(body.level, kind);
+
+  const message = body.message ??
+    (kind ? `Client ${kind} event` : "Client observability event");
+
+  logger.log(level, message, buildLogContext(request, body));
+
+  return NextResponse.json({ status: "ok" }, { status: 200 });
+}
+
+export const runtime = "nodejs";

--- a/apps/web/core/lib/monitoring/app-monitor.ts
+++ b/apps/web/core/lib/monitoring/app-monitor.ts
@@ -2,6 +2,11 @@
 
 import { captureError, captureSuccess } from "@/helpers/event-tracker.helper";
 import { type NormalizedError, normalizeError } from "@/lib/monitoring/error-normalizer";
+import {
+  reportNetlifyClientError,
+  reportNetlifyClientMetric,
+  reportNetlifyLifecycleEvent,
+} from "./netlify-reporter";
 import { PerformanceMetricsCollector, type PerformanceMetricReporter } from "./performance-metrics";
 
 type ErrorContext = Record<string, unknown>;
@@ -51,6 +56,12 @@ const reportThroughAnalytics = (
     payload: { severity: "critical", origin: source },
     context: { ...buildRuntimeContext(), ...context },
   });
+  reportNetlifyClientError("app_monitor_error", {
+    error: normalizedError,
+    source,
+    context: { ...buildRuntimeContext(), ...context },
+    payload: { severity: "critical" },
+  });
 };
 
 const reportPerformanceMetric: PerformanceMetricReporter = (metric, payload) => {
@@ -59,6 +70,7 @@ const reportPerformanceMetric: PerformanceMetricReporter = (metric, payload) => 
     payload: { metric, ...payload },
     context: buildRuntimeContext(),
   });
+  reportNetlifyClientMetric(metric, payload, buildRuntimeContext());
 };
 
 export class AppMonitor {
@@ -107,6 +119,8 @@ export class AppMonitor {
     this.installLongTaskObserver();
 
     this.performanceCollector.start();
+
+    reportNetlifyLifecycleEvent("app_monitor_started", buildRuntimeContext());
   }
 
   stop(): void {
@@ -117,6 +131,8 @@ export class AppMonitor {
     } catch {
       // ignore
     }
+
+    reportNetlifyLifecycleEvent("app_monitor_stopped", buildRuntimeContext());
 
     while (this.removeListeners.length) {
       const remove = this.removeListeners.pop();
@@ -212,6 +228,17 @@ export class AppMonitor {
             startTime: entry.startTime,
             threshold: LONG_TASK_THRESHOLD,
           });
+          reportNetlifyClientMetric(
+            "long_task_detected",
+            {
+              duration,
+              entryType: entry.entryType,
+              name: entry.name,
+              startTime: entry.startTime,
+              threshold: LONG_TASK_THRESHOLD,
+            },
+            buildRuntimeContext()
+          );
         }
       });
 

--- a/apps/web/core/lib/monitoring/netlify-reporter.ts
+++ b/apps/web/core/lib/monitoring/netlify-reporter.ts
@@ -1,0 +1,233 @@
+"use client";
+
+import { type NormalizedError, stringifyUnknown } from "@/lib/monitoring/error-normalizer";
+
+type NetlifyLogLevel = "debug" | "info" | "warn" | "error";
+type NetlifyLogKind = "error" | "metric" | "lifecycle";
+
+type NetlifyClientEventBase = {
+  kind: NetlifyLogKind;
+  name: string;
+  level?: NetlifyLogLevel;
+  message?: string;
+  context?: Record<string, unknown>;
+  payload?: Record<string, unknown>;
+  timestamp?: string;
+};
+
+type NetlifyClientErrorEvent = NetlifyClientEventBase & {
+  kind: "error";
+  error: NormalizedError;
+  source: string;
+};
+
+type NetlifyClientMetricEvent = NetlifyClientEventBase & {
+  kind: "metric";
+  metric: string;
+};
+
+type NetlifyClientLifecycleEvent = NetlifyClientEventBase & {
+  kind: "lifecycle";
+};
+
+type NetlifyClientEvent =
+  | NetlifyClientErrorEvent
+  | NetlifyClientMetricEvent
+  | NetlifyClientLifecycleEvent;
+
+const LOG_ENDPOINT = "/api/monitoring/log";
+const MAX_BODY_LENGTH = 40_000;
+
+const truthy = (value: string | boolean | undefined | null): boolean => {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return false;
+  switch (value.toLowerCase()) {
+    case "1":
+    case "true":
+    case "yes":
+    case "on":
+      return true;
+    default:
+      return false;
+  }
+};
+
+const resolveLoggingEnabled = (): boolean => {
+  const envFlag =
+    typeof process !== "undefined"
+      ? process.env.NEXT_PUBLIC_ENABLE_NETLIFY_LOGS ?? process.env.NEXT_PUBLIC_ENABLE_CLIENT_LOGS
+      : undefined;
+
+  if (truthy(envFlag)) return true;
+
+  const globalScope = globalThis as typeof globalThis & {
+    __PLANE_ENABLE_NETLIFY_LOGS__?: boolean;
+  };
+
+  return truthy(globalScope.__PLANE_ENABLE_NETLIFY_LOGS__);
+};
+
+const isLoggingEnabled = resolveLoggingEnabled();
+
+const truncateString = (value: string, maxLength: number): string => {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}…`;
+};
+
+const safePayload = (payload: Record<string, unknown> | undefined): Record<string, unknown> | undefined => {
+  if (!payload) return undefined;
+  const result: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(payload)) {
+    if (typeof raw === "string") {
+      result[key] = truncateString(raw, 2048);
+    } else if (Array.isArray(raw)) {
+      result[key] = raw.slice(0, 20).map((item) => {
+        if (typeof item === "string") return truncateString(item, 1024);
+        if (typeof item === "number" || typeof item === "boolean" || item === null) {
+          return item;
+        }
+        if (typeof item === "object" && item !== null) {
+          try {
+            return JSON.parse(JSON.stringify(item));
+          } catch {
+            return stringifyUnknown(item);
+          }
+        }
+        return stringifyUnknown(item);
+      });
+    } else if (typeof raw === "object" && raw !== null) {
+      try {
+        result[key] = JSON.parse(JSON.stringify(raw));
+      } catch {
+        result[key] = stringifyUnknown(raw);
+      }
+    } else {
+      result[key] = raw;
+    }
+  }
+  return result;
+};
+
+const serializeError = (error: NormalizedError): Record<string, unknown> => ({
+  name: error.name,
+  message: truncateString(error.message, 2048),
+  stack: error.stack ? truncateString(error.stack, 4096) : undefined,
+  cause:
+    typeof error.cause === "string"
+      ? truncateString(error.cause, 1024)
+      : error.cause
+        ? truncateString(stringifyUnknown(error.cause), 1024)
+        : undefined,
+});
+
+const buildRequestBody = (event: NetlifyClientEvent): string | undefined => {
+  if (!isLoggingEnabled) return undefined;
+
+  const timestamp = event.timestamp ?? new Date().toISOString();
+  const base: Record<string, unknown> = {
+    kind: event.kind,
+    name: event.name,
+    level: event.level ?? (event.kind === "error" ? "error" : "info"),
+    timestamp,
+    runtime: "browser",
+  };
+
+  if (event.message) base.message = truncateString(event.message, 2048);
+  if (event.context) base.context = safePayload(event.context);
+  if (event.payload) base.payload = safePayload(event.payload);
+
+  if (event.kind === "error") {
+    base.error = serializeError(event.error);
+    base.source = event.source;
+  }
+
+  if (event.kind === "metric") {
+    base.metric = event.metric;
+  }
+
+  const serialized = JSON.stringify(base);
+  if (serialized.length > MAX_BODY_LENGTH) {
+    return JSON.stringify({
+      ...base,
+      truncated: true,
+    });
+  }
+
+  return serialized;
+};
+
+const sendBeacon = (body: string) => {
+  try {
+    if (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function") {
+      const blob = new Blob([body], { type: "application/json" });
+      navigator.sendBeacon(LOG_ENDPOINT, blob);
+      return;
+    }
+  } catch (error) {
+    // Ignore sendBeacon failures and fall back to fetch
+  }
+
+  if (typeof fetch === "function") {
+    fetch(LOG_ENDPOINT, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+      keepalive: true,
+      cache: "no-store",
+    }).catch(() => {
+      // Swallow fetch errors; logging should be fire-and-forget
+    });
+  }
+};
+
+const dispatchEvent = (event: NetlifyClientEvent) => {
+  const body = buildRequestBody(event);
+  if (!body) return;
+  sendBeacon(body);
+};
+
+export const reportNetlifyClientError = (
+  name: string,
+  params: {
+    error: NormalizedError;
+    context?: Record<string, unknown>;
+    payload?: Record<string, unknown>;
+    source: string;
+  }
+) => {
+  dispatchEvent({
+    kind: "error",
+    name,
+    error: params.error,
+    context: params.context,
+    payload: params.payload,
+    source: params.source,
+  });
+};
+
+export const reportNetlifyClientMetric = (
+  metric: string,
+  payload: Record<string, unknown>,
+  context?: Record<string, unknown>
+) => {
+  dispatchEvent({
+    kind: "metric",
+    name: `metric:${metric}`,
+    metric,
+    payload,
+    context,
+  });
+};
+
+export const reportNetlifyLifecycleEvent = (
+  name: string,
+  payload?: Record<string, unknown>,
+  level: NetlifyLogLevel = "info"
+) => {
+  dispatchEvent({
+    kind: "lifecycle",
+    name,
+    payload,
+    level,
+  });
+};

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -40,7 +40,12 @@ export async function register(): Promise<void> {
     logger.error(
       formatMessage("Unhandled promise rejection detected.", [
         describeNormalizedError(normalized),
-      ])
+      ]),
+      {
+        channel: "server.monitoring",
+        event: "unhandled_rejection",
+        normalized_error: normalized,
+      }
     );
   };
 
@@ -49,14 +54,24 @@ export async function register(): Promise<void> {
     logger.error(
       formatMessage("Uncaught exception detected.", [
         describeNormalizedError(normalized),
-      ])
+      ]),
+      {
+        channel: "server.monitoring",
+        event: "uncaught_exception",
+        normalized_error: normalized,
+      }
     );
   };
 
   const handleWarning = (warning: Error) => {
     const normalized = normalizeError(warning);
     logger.warn(
-      formatMessage("Process warning emitted.", [describeNormalizedError(normalized)])
+      formatMessage("Process warning emitted.", [describeNormalizedError(normalized)]),
+      {
+        channel: "server.monitoring",
+        event: "process_warning",
+        normalized_error: normalized,
+      }
     );
   };
 
@@ -65,7 +80,11 @@ export async function register(): Promise<void> {
       logger.debug(
         formatMessage("Promise rejection handled after being reported.", [
           `promise=${stringifyUnknown(promise)}`,
-        ])
+        ]),
+        {
+          channel: "server.monitoring",
+          event: "rejection_handled",
+        }
       );
     }
   };
@@ -75,5 +94,8 @@ export async function register(): Promise<void> {
   process.on("warning", handleWarning);
   process.on("rejectionHandled", handleRejectionHandled);
 
-  logger.info("Server monitoring hooks registered for Plane Web.");
+  logger.info("Server monitoring hooks registered for Plane Web.", {
+    channel: "server.monitoring",
+    event: "monitoring_registered",
+  });
 }

--- a/packages/logger/src/config.ts
+++ b/packages/logger/src/config.ts
@@ -1,9 +1,10 @@
+import path from "path";
 import winston from "winston";
 import DailyRotateFile from "winston-daily-rotate-file";
-import path from "path";
 
-// Define log levels
-const levels = {
+type LogLevel = "error" | "warn" | "info" | "http" | "debug";
+
+const LOG_LEVELS: Record<LogLevel, number> = {
   error: 0,
   warn: 1,
   info: 2,
@@ -11,8 +12,7 @@ const levels = {
   debug: 4,
 };
 
-// Define colors for each level
-const colors = {
+const LOG_COLORS: Record<LogLevel, string> = {
   error: "red",
   warn: "yellow",
   info: "green",
@@ -20,47 +20,163 @@ const colors = {
   debug: "white",
 };
 
-// Tell winston about our colors
-winston.addColors(colors);
+const NETLIFY_ENV_FLAGS = ["NETLIFY", "ENABLE_NETLIFY_LOGS", "PLANE_NETLIFY_LOGS"] as const;
 
-// Custom format for logging
-const format = winston.format.combine(
+const SPLAT_SYMBOL = Symbol.for("splat");
+
+const isTruthy = (value: string | undefined | null | boolean): boolean => {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return false;
+  switch (value.toLowerCase()) {
+    case "1":
+    case "true":
+    case "yes":
+    case "on":
+      return true;
+    default:
+      return false;
+  }
+};
+
+const shouldDisableFileLogs = (): boolean => {
+  if (isTruthy(process.env.LOG_DISABLE_FILES)) return true;
+  return NETLIFY_ENV_FLAGS.some((flag) => isTruthy(process.env[flag]));
+};
+
+const shouldUseJsonConsole = (): boolean => {
+  const configuredFormat = process.env.LOG_FORMAT;
+  if (typeof configuredFormat === "string" && configuredFormat.toLowerCase() === "json") {
+    return true;
+  }
+  if (isTruthy(process.env.LOG_CONSOLE_JSON)) return true;
+  return NETLIFY_ENV_FLAGS.some((flag) => isTruthy(process.env[flag]));
+};
+
+const safeSerialize = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) {
+    return JSON.stringify(
+      {
+        name: value.name,
+        message: value.message,
+        stack: value.stack,
+      },
+      undefined,
+      0
+    );
+  }
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    return String(value);
+  }
+};
+
+const metadataFormatter = winston.format((info) => {
+  const extras: unknown[] = [];
+  const splat = (info as Record<string, unknown>)[SPLAT_SYMBOL as unknown as string];
+
+  if (Array.isArray(splat)) {
+    extras.push(...splat);
+  }
+
+  const shallowInfo = { ...info } as Record<string, unknown>;
+  delete shallowInfo.level;
+  delete shallowInfo.message;
+  delete shallowInfo.timestamp;
+  delete shallowInfo[SPLAT_SYMBOL as unknown as string];
+
+  if (Object.keys(shallowInfo).length) {
+    extras.push(shallowInfo);
+  }
+
+  return { ...info, metadata: extras };
+});
+
+const humanReadableFormat = winston.format.combine(
   winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss:ms" }),
   winston.format.colorize({ all: true }),
-  winston.format.printf(
-    (info: winston.Logform.TransformableInfo) => `[${info?.timestamp}] ${info.level}: ${info.message}`
-  )
+  winston.format.errors({ stack: true }),
+  winston.format.splat(),
+  metadataFormatter,
+  winston.format.printf((info: winston.Logform.TransformableInfo & { metadata?: unknown[] }) => {
+    const metadata = Array.isArray(info.metadata) ? info.metadata : [];
+    const metaString = metadata
+      .map((item) => safeSerialize(item))
+      .filter(Boolean)
+      .join(" ");
+    const suffix = metaString ? ` ${metaString}` : "";
+    return `[${info.timestamp}] ${info.level}: ${info.message}${suffix}`;
+  })
 );
 
-// Define which transports to use
+const jsonFormat = winston.format.combine(
+  winston.format.timestamp({ format: () => new Date().toISOString() }),
+  winston.format.errors({ stack: true }),
+  winston.format.splat(),
+  metadataFormatter,
+  winston.format.uncolorize(),
+  winston.format.printf((info: winston.Logform.TransformableInfo & { metadata?: unknown[] }) => {
+    const payload: Record<string, unknown> = {
+      timestamp: info.timestamp,
+      level: info.level,
+      message: info.message,
+    };
+
+    if (Array.isArray(info.metadata) && info.metadata.length) {
+      payload.metadata = info.metadata.map((entry) => {
+        if (entry instanceof Error) {
+          return {
+            name: entry.name,
+            message: entry.message,
+            stack: entry.stack,
+          };
+        }
+        if (typeof entry === "object" && entry !== null) {
+          return entry;
+        }
+        return safeSerialize(entry);
+      });
+    }
+
+    return JSON.stringify(payload);
+  })
+);
+
+winston.addColors(LOG_COLORS);
+
 const transports = [
-  // Console transport
-  new winston.transports.Console(),
-
-  // Rotating file transport for errors
-  new DailyRotateFile({
-    filename: path.join(process.cwd(), "logs", "error-%DATE%.log"),
-    datePattern: "YYYY-MM-DD",
-    zippedArchive: true,
-    maxSize: process.env.LOG_MAX_SIZE || "20m",
-    maxFiles: process.env.LOG_RETENTION || "7d",
-    level: "error",
-  }),
-
-  // Rotating file transport for all logs
-  new DailyRotateFile({
-    filename: path.join(process.cwd(), "logs", "combined-%DATE%.log"),
-    datePattern: "YYYY-MM-DD",
-    zippedArchive: true,
-    maxSize: process.env.LOG_MAX_SIZE || "20m",
-    maxFiles: process.env.LOG_RETENTION || "7d",
+  new winston.transports.Console({
+    level: process.env.LOG_LEVEL || "info",
   }),
 ];
 
-// Create the logger
+if (!shouldDisableFileLogs()) {
+  transports.push(
+    new DailyRotateFile({
+      filename: path.join(process.cwd(), "logs", "error-%DATE%.log"),
+      datePattern: "YYYY-MM-DD",
+      zippedArchive: true,
+      maxSize: process.env.LOG_MAX_SIZE || "20m",
+      maxFiles: process.env.LOG_RETENTION || "7d",
+      level: "error",
+    })
+  );
+
+  transports.push(
+    new DailyRotateFile({
+      filename: path.join(process.cwd(), "logs", "combined-%DATE%.log"),
+      datePattern: "YYYY-MM-DD",
+      zippedArchive: true,
+      maxSize: process.env.LOG_MAX_SIZE || "20m",
+      maxFiles: process.env.LOG_RETENTION || "7d",
+    })
+  );
+}
+
 export const logger = winston.createLogger({
   level: process.env.LOG_LEVEL || "info",
-  levels,
-  format,
+  levels: LOG_LEVELS,
+  format: shouldUseJsonConsole() ? jsonFormat : humanReadableFormat,
   transports,
 });


### PR DESCRIPTION
## Summary
- add a client-side Netlify logging reporter and API route so browser monitoring events flow into Netlify server logs
- upgrade the shared logger to emit structured JSON in Netlify environments and avoid file transports that cannot be written in serverless runtimes
- initialize and harden OpenTelemetry tracing across Django, ASGI/WSGI, and Celery entrypoints with defensive configuration and shutdown logging

## Testing
- yarn --cwd apps/web check:types *(fails: workspace packages such as @plane/ui and @plane/constants are missing type declarations in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7885ca46c832996601fc358acfc30